### PR TITLE
Convert all docstrings to numpy format

### DIFF
--- a/bin/test_formatting
+++ b/bin/test_formatting
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Test formatting of fecon236
+# REQUIRES: flake8, flake8-rst
+
+cd ..
+echo "$(pwd)"
+
+# Ensure required dependencies are installed
+flake8 > /dev/null 2>&1
+rc=$?; if [[ $rc != 0 ]]; then
+    echo >&2 "I require flake8. Use 'pip install flake8' to install"
+fi
+
+flake8-rst > /dev/null 2>&1
+rc=$?; if [[ $rc != 0 ]]; then
+    echo >&2 "I require flake8-rst. Use 'pip install flake8-rst' to install"
+fi
+
+echo "flake8 check..."
+flake8 .
+rc=$?; if [[ $rc != 0 ]]; then
+    echo >&2 "flake8 check failed."
+fi
+echo "PASSED"
+
+echo "flake8-rst check..."
+flake8-rst .
+rc=$?; if [[ $rc != 0 ]]; then
+    echo >&2 "flake8-rst check failed."
+fi
+echo "PASSED"
+
+echo "ALL FORMATTING CHECKS PASSED"

--- a/bin/test_formatting
+++ b/bin/test_formatting
@@ -4,7 +4,6 @@
 # REQUIRES: flake8, flake8-rst
 
 cd ..
-echo "$(pwd)"
 
 # Ensure required dependencies are installed
 flake8 > /dev/null 2>&1
@@ -17,6 +16,7 @@ rc=$?; if [[ $rc != 0 ]]; then
     echo >&2 "I require flake8-rst. Use 'pip install flake8-rst' to install"
 fi
 
+# Test flake8 formatting
 echo "flake8 check..."
 flake8 .
 rc=$?; if [[ $rc != 0 ]]; then
@@ -24,6 +24,7 @@ rc=$?; if [[ $rc != 0 ]]; then
 fi
 echo "PASSED"
 
+# Test flake8 formatting in embedded code blocks
 echo "flake8-rst check..."
 flake8-rst .
 rc=$?; if [[ $rc != 0 ]]; then

--- a/fecon236/boots/bootstrap.py
+++ b/fecon236/boots/bootstrap.py
@@ -1,6 +1,6 @@
 #  Python Module for import                           Date : 2018-07-07
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-"""Bootstrap module for fecon236
+"""Bootstrap module for ``fecon236``
 
 - Efficient storage and rescaling of empirical data.
     - Normalize, but retain features of the empirical distribution.
@@ -8,8 +8,8 @@
     - Visualize sample price paths.
     - Bootstrap for small-sample statistics.
     - Bootstrap for determining probabilities of events.
-- Specify hybrid population array using synthetic rates of return
-  from GM(2) Gaussian Mixture model.
+- Specify hybrid population array using synthetic rates of return from GM(2)
+  Gaussian Mixture model.
 
 
 Usage
@@ -157,15 +157,16 @@ def hybrid2ret(poparr, mean=SPXmean, sigma=SPXsigma, yearly=256):
 
 
 def bootstrap(N, poparr, replace=True):
-    """Randomly pick out N items from poparr.
+    """Randomly pick out ``N`` items from ``poparr``.
 
     Notes
     -----
-    Default argument, replace=True, means "WITH replacement."
+    Default argument, ``replace=True``, means "WITH replacement."
+
+    Note that ``replace=False`` is useful during testing to replicate
+    the entire population if necessary (e.g. to check terminal price).
+    The theory on bootstrap generally assumes ``replace=True``.
     """
-    #  Note that replace=False is useful during testing to replicate
-    #  the entire population if necessary (e.g. to check terminal price).
-    #  The theory on bootstrap generally assumes replace=True.
     bsarr = np.random.choice(poparr, size=N, replace=replace)
     #      BOOTSTRAPPED array
     return bsarr

--- a/fecon236/dst/gaussmix.py
+++ b/fecon236/dst/gaussmix.py
@@ -1,6 +1,6 @@
 #  Python Module for import                           Date : 2018-11-10
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-r"""Gaussian mixture distribution for fecon236
+r"""Gaussian mixture distribution for ``fecon236``
 
 - Refinement of geometric mean computations relies on Jean (1983)
   which derives an exact infinite series of higher moments, wherein

--- a/fecon236/dst/gaussmix.py
+++ b/fecon236/dst/gaussmix.py
@@ -174,13 +174,16 @@ def gm2_vols(data, b=2.5, yearly=256):
     .. code-block:: python
 
         gm2_vols(spx['1957':], b=3.4)
-        # [6.4231, 4.878, 52.8776, 0.07866443, 31.5634, 15.5522, 3.4, 256, 15748]
+        # [6.4231, 4.878, 52.8776, 0.07866443, 31.5634,
+           15.5522, 3.4, 256, 15748]
 
         gm2_vols(spx['1997':], b=2.0)
-        # [5.6690, 5.8802435, 38.5585, 0.232142, 11.1628, 19.2793, 2.0, 256, 5313]
+        # [5.6690, 5.8802435, 38.5585, 0.232142, 11.1628,
+           19.2793, 2.0, 256, 5313]
 
         gm2_vols(spx['2007':], b=2.2)
-        # [4.9873, 5.1699, 44.8882, 0.195946, 13.7804, 20.4037, 2.2, 256, 2705]
+        # [4.9873, 5.1699, 44.8882, 0.195946, 13.7804, 20.4037,
+           2.2, 256, 2705]
 
     So one might suppose a typical set of outputs would look like:
 
@@ -216,7 +219,6 @@ def gm2_vols(data, b=2.5, yearly=256):
     #  ... the mean return mu is still arithmetic, not geometric:
     return [mu*yc, sigma1*ysr, sigma2*ysr, q,
             k_Pearson, sigma*ysr, b, yearly, N]
-
 
 
 #  #  DEPRECATED 2017-05-21: If geometric mean approximation is only a

--- a/fecon236/dst/gaussmix.py
+++ b/fecon236/dst/gaussmix.py
@@ -172,6 +172,7 @@ def gm2_vols(data, b=2.5, yearly=256):
     2017-05-16  Outputs given SPX, informally minimizing b until fatal:
 
     .. code-block:: python
+        :flake8-group: Ignore
 
         gm2_vols(spx['1957':], b=3.4)
         # [6.4231, 4.878, 52.8776, 0.07866443, 31.5634,

--- a/fecon236/dst/gaussmix.py
+++ b/fecon236/dst/gaussmix.py
@@ -1,70 +1,80 @@
 #  Python Module for import                           Date : 2018-11-10
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-r'''
-_______________|  gaussmix.py :: Gaussian mixture distribution for fecon236
+r"""Gaussian mixture distribution for fecon236
 
 - Refinement of geometric mean computations relies on Jean (1983)
   which derives an exact infinite series of higher moments, wherein
   the premature truncation in the classic paper Young (1969) is corrected.
 
-- Tests of this module at tests/test_gaussmix.py
+Notes
+-----
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-11-10  Minor: raw string mode for intro, fix #6 flake8 W605 SyntaxError.
-2018-07-08  Change from np.std() to tool.std() for population argument.
-2018-07-04  On excessive kurtosis, change system.die to OverflowError.
-2018-06-03  Rename to gaussmix.py, fecon236 fork. Pass flake8, fix imports.
-2017-06-29  ys_gauss_mix.py, fecon235 v5.18.0312, https://git.io/fecon235
-                Fallback clause for gemrate() when log fails (2008Q4).
-2017-05-21  Deprecate gm2_georet() and georet_gm2() due to math proof.
-                For geometric mean computations, add gemreturn_Jean(),
-                gemrate(), and for data: georat().
+- Tests of this module at ``tests/test_gaussmix.py``
+- For LATEST version, see https://git.io/fecon236
 
 
-_______________ STRUCTURED zero-mean GM(2), from https://git.io/gmix
+Structured Zero Mean GM(2)
+--------------------------
 
-Given data set {$x$}, we can compute its variance and kurtosis.
-Thus, $\sigma$ and $\rm K$ are observable.
-Corollary 1.2 says that GM(2) parameters can indeed synthesize $\rm K$,
+Given data set {:math:`x`}, we can compute its variance and kurtosis.
+Thus, :math:`\sigma` and :math:`\rm K` are observable.
+Corollary 1.2 says that GM(2) parameters can indeed synthesize :math:`\rm K`,
 but its messiness suggests that we impose further structure for clarity.
 A sensible requirement is a strict ordering,
-$\sigma_1 < \sigma < \sigma_2$
-in consideration of the weighted equation for $\sigma^2$.
-We can impose this ordering by constrained constants $a$ and $b$.
+:math:`\sigma_1 < \sigma < \sigma_2`
+in consideration of the weighted equation for :math:`\sigma^2`.
+We can impose this ordering by constrained constants :math:`a` and :math:`b`.
 
-PROPOSITION 2: Let $\sigma_1 = a\sigma$ and $b\sigma = \sigma_2$
-such that $0<a<1<b$, then for zero-mean GM(2)
+PROPOSITION 2: Let :math:`\sigma_1 = a\sigma` and :math:`b\sigma = \sigma_2`
+such that :math:`0<a<1<b`, then for zero-mean GM(2)
 the following satisfies conditions for both kurtosis and variance:
 
-$$\frac{\rm K - b^4}{a^4 - b^4} = \frac{1 - b^2}{a^2 - b^2}$$
+.. math::
 
-This shows how constants $a$ and $b$ are jointly constrained
+    \frac{\rm K - b^4}{a^4 - b^4} = \frac{1 - b^2}{a^2 - b^2}
+
+This shows how constants :math:`a` and :math:`b` are jointly constrained
 by the moments of the Gaussian mixture.
 
-Our STRATEGY will be to choose $b>1$, then use the kurtosis $\kappa$
-to compute $a$. Probability $p$ can then be computed using
-Lemma 2.2, for which $q=1-p$ follows.
-Since $\sigma_1 = a\sigma$ and $b\sigma = \sigma_2$
+Our STRATEGY will be to choose :math:`b>1`, then use the kurtosis $\kappa$
+to compute :math:`a`. Probability :math:`p` can then be computed using
+Lemma 2.2, for which :math:`q=1-p` follows.
+Since :math:`\sigma_1 = a\sigma` and :math:`b\sigma = \sigma_2`
 the components of our zero-mean GM(2) are fully resolved,
-given specific $\sigma$.
+given specific :math:`\sigma`.
 
-From two observable statistics $\sigma$ and $\kappa$,
+From two observable statistics :math:`\sigma` and :math:`\kappa`,
 we have deduced, not fitted, the parameters of a zero-mean GM(2).
-An observable mean $\mu$ which is non-zero can be added to
+An observable mean :math:`\mu` which is non-zero can be added to
 our model to obtain a zero-skew GM(2).
 
-REFERENCES:
+References
+----------
 
 - Gaussian Mixture and Leptokurtotic Assets, 2017, Jupyter notebook,
   https://github.com/rsvp/fecon235/blob/master/nb/gauss-mix-kurtosis.ipynb
-
 - William H. JEAN and Billy P. Helms, 1983, Geometric Mean Approximations,
   J. Financial and Quantitative Analysis, 18:3:287-293.
-
 - William E. YOUNG and Robert H. Trent, 1969, Geometric Mean Approximations
   of Individual Security and Portfolio Performance,
   J. Financial and Quantitative Analysis, 4:2:179-199.
-'''
+
+Change Log
+----------
+
+* 2018-11-10  Minor: raw string mode for intro, fix #6 flake8 W605 SyntaxError.
+* 2018-07-08  Change from ``np.std`` to ``tool.std`` for population argument.
+* 2018-07-04  On excessive kurtosis, change ``system.die`` to
+  ``OverflowError``.
+* 2018-06-03  Rename to ``gaussmix.py``, ``fecon236`` fork. Pass flake8, fix
+  imports.
+* 2017-06-29  ``ys_gauss_mix.py``, fecon235 v5.18.0312, https://git.io/fecon235
+  Fallback clause for ``gemrate`` when log fails (2008Q4).
+* 2017-05-21  Deprecate ``gm2_georet`` and ``georet_gm2`` due to math proof.
+  For geometric mean computations, add ``gemreturn_Jean``, ``gemrate``, and for
+  data: ``georat``.
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -75,7 +85,7 @@ from fecon236.util import system
 
 
 def gm2_strategy(kurtosis, b=2):
-    '''Use sympy to solve for "a" in Proposition 2 numerically.'''
+    """Use sympy to solve for "a" in Proposition 2 numerically."""
     #  sym.init_printing(use_unicode=True)
     #  #        ^required if symbolic output is desired.
     a = sym.symbols('a')
@@ -100,7 +110,7 @@ def gm2_strategy(kurtosis, b=2):
 
 
 def gm2_main(kurtosis, sigma, b=2):
-    '''Compute specs for GM(2) given observable statistics and b.'''
+    """Compute specs for GM(2) given observable statistics and b."""
     a = gm2_strategy(kurtosis, b)
     #  Probability p as given in Lemma 2.2:
     p = float((1 - (b**2)) / ((a**2) - (b**2)))
@@ -115,7 +125,7 @@ def gm2_main(kurtosis, sigma, b=2):
 
 
 def gm2_print(kurtosis, sigma, b=2):
-    '''Print specs for GM(2) given observable statistics and b.'''
+    """Print specs for GM(2) given observable statistics and b."""
     specs = gm2_main(kurtosis, sigma, b)
     print("Constants a, b:", specs[0])
     print("GM(2), p: ", specs[1][0])
@@ -128,8 +138,14 @@ def gm2_print(kurtosis, sigma, b=2):
 
 
 def gm2_vols_fit(data, b=2.5):
-    '''Estimate GM(2) VOLATILITY parameters including mu, given b.'''
-    #  Our data is presumed to be prices of some financial asset.
+    """Estimate GM(2) VOLATILITY parameters including mu, given b.
+
+    Notes
+    -----
+
+    * Our data is presumed to be prices of some financial asset.
+
+    """
     rat = tool.diflog(data, lags=1)
     #          ^First difference of log(data).
     arr = tool.df2a(rat)
@@ -150,9 +166,49 @@ def gm2_vols_fit(data, b=2.5):
 
 
 def gm2_vols(data, b=2.5, yearly=256):
-    '''Compute GM(2) ANNUALIZED VOLATILITY in percentage form, given b.'''
-    #  Our data is presumed to be prices of some financial asset.
-    #  Argument yearly expresses frequency of data, default is business daily.
+    """Compute GM(2) ANNUALIZED VOLATILITY in percentage form, given b.
+
+
+    2017-05-16  Outputs given SPX, informally minimizing b until fatal:
+
+    .. code-block:: python
+
+        gm2_vols(spx['1957':], b=3.4)
+        # [6.4231, 4.878, 52.8776, 0.07866443, 31.5634, 15.5522, 3.4, 256, 15748]
+
+        gm2_vols(spx['1997':], b=2.0)
+        # [5.6690, 5.8802435, 38.5585, 0.232142, 11.1628, 19.2793, 2.0, 256, 5313]
+
+        gm2_vols(spx['2007':], b=2.2)
+        # [4.9873, 5.1699, 44.8882, 0.195946, 13.7804, 20.4037, 2.2, 256, 2705]
+
+    So one might suppose a typical set of outputs would look like:
+
+    .. csv-table:: Outputs
+
+        Annualized mean return,  5.69%
+        Annualized sigma1,  5.30938
+        Annualized sigma2, 45.44142
+        Probability sigma2,  0.1689
+        kurtosis, 18.8355
+        Annualized sigma, 18.411734
+
+    where b around 2.533 might work, but not always.
+
+    Our sigma2 guess is interesting since "double or nothing"
+    is just 2.2 standard deviations away. The probability of
+    drawing from the second Gaussian with the higher volatility
+    of 45% is about 0.17. The compensation for such risks taken
+    is the annual mean return of 5.7%, plus dividends collected.
+
+
+    Notes
+    -----
+
+    * Our data is presumed to be prices of some financial asset.
+    * Argument yearly expresses frequency of data, default is business daily.
+
+    """
     mu, sigma1, sigma2, q, k_Pearson, sigma, b, N = gm2_vols_fit(data, b)
     #  ANNUALIZE appropriately in "percentage" form...
     yc = 100 * yearly
@@ -161,31 +217,6 @@ def gm2_vols(data, b=2.5, yearly=256):
     return [mu*yc, sigma1*ysr, sigma2*ysr, q,
             k_Pearson, sigma*ysr, b, yearly, N]
 
-    #  2017-05-16  Outputs given SPX, informally minimizing b until fatal:
-    #
-    #  >>> gm2_vols(spx['1957':], b=3.4)
-    #  [6.4231, 4.878, 52.8776, 0.07866443, 31.5634, 15.5522, 3.4, 256, 15748]
-    #
-    #  >>> gm2_vols(spx['1997':], b=2.0)
-    #  [5.6690, 5.8802435, 38.5585, 0.232142, 11.1628, 19.2793, 2.0, 256, 5313]
-    #
-    #  >>> gm2_vols(spx['2007':], b=2.2)
-    #  [4.9873, 5.1699, 44.8882, 0.195946, 13.7804, 20.4037, 2.2, 256, 2705]
-    #
-    #  So one might suppose a typical set of outputs would look like:
-    #      Annualized mean return:  5.69%
-    #           Annualized sigma1:  5.30938
-    #           Annualized sigma2: 45.44142
-    #          Probability sigma2:  0.1689
-    #                    kurtosis: 18.8355
-    #            Annualized sigma: 18.411734
-    #                where b around 2.533 might work, but not always.
-    #
-    #  Our sigma2 guess is interesting since "double or nothing"
-    #  is just 2.2 standard deviations away. The probability of
-    #  drawing from the second Gaussian with the higher volatility
-    #  of 45% is about 0.17. The compensation for such risks taken
-    #  is the annual mean return of 5.7%, plus dividends collected.
 
 
 #  #  DEPRECATED 2017-05-21: If geometric mean approximation is only a
@@ -194,7 +225,7 @@ def gm2_vols(data, b=2.5, yearly=256):
 #  #             does not mathematically refine the approximation!
 #
 #  def gm2_georet(mu, sigma1, sigma2, q=0.10, yearly=1):
-#      '''Define GEOMETRIC mean return for GM(2) Gaussian mixture model.'''
+#      """Define GEOMETRIC mean return for GM(2) Gaussian mixture model."""
 #      #  Argument q is the probability of the second Gaussian.
 #      #  Argument yearly is a scale parameter to express frequency of data.
 #      #   Default yearly=1 produces a plain unscaled geometric mean return.
@@ -209,10 +240,13 @@ def gm2_vols(data, b=2.5, yearly=256):
 
 
 def gemreturn_Jean(mu_return, sigma, k_Pearson=3):
-    '''Approximation for geometric mean RETURN via Jean (1983) infinite series.
-       Important definition: "financial return":= 1 + "rate"
-       where rate is expressed in decimal form.
-    '''
+    """Approximation for geometric mean RETURN via Jean (1983) infinite series.
+
+    Notes
+    -----
+    Important definition: "financial return":= 1 + "rate" where rate is
+    expressed in decimal form.
+    """
     #  Jean (1983) derived the exact infinite series for geometric mean return
     #  around a reference point (the arithmetic mean return worked out best).
     #  Here we code an approximation by the first five terms of that series:
@@ -231,10 +265,13 @@ def gemreturn_Jean(mu_return, sigma, k_Pearson=3):
 
 
 def gemrate(mu_rate, sigma, kurtosis=3, yearly=1):
-    '''Approximation for annualized geometric mean RATE by preferred method.
-       Important definition: "financial return":= 1 + "rate"
-       where rate is expressed in decimal form.
-    '''
+    """Approximation for annualized geometric mean RATE by preferred method.
+
+    Notes
+    -----
+    Important definition: "financial return":= 1 + "rate" where rate is
+    expressed in decimal form.
+    """
     mu_return = 1 + mu_rate
     k_Pearson = kurtosis
     #           ^MUST be expressed as Pearson kurtosis here, see kurtfun().
@@ -255,11 +292,14 @@ def gemrate(mu_rate, sigma, kurtosis=3, yearly=1):
 
 
 def gemrat(data, yearly=256, pc=True):
-    '''Compute annualized geometric mean rate for given data.
-       Output will be more accurate than the method implicit in georet()
-       since the kurtosis of differenced log data matters.
-       Argument pc will present appropriate output in percentage form.
-    '''
+    """Compute annualized geometric mean rate for given data.
+
+    Notes
+    -----
+    Output will be more accurate than the method implicit in georet() since the
+    kurtosis of differenced log data matters. Argument pc will present
+    appropriate output in percentage form.
+    """
     rat = tool.diflog(data, lags=1)
     #          ^First difference of log(data).
     arr = tool.df2a(rat)
@@ -292,9 +332,12 @@ def gemrat(data, yearly=256, pc=True):
 
 
 def gm2gemrat(data, yearly=256, b=2.5, pc=True):
-    '''Compute annualized geometric mean rate and GM(2) parameters.
-       Argument pc will present appropriate output in percentage form.
-    '''
+    """Compute annualized geometric mean rate and GM(2) parameters.
+
+    Notes
+    -----
+    Argument pc will present appropriate output in percentage form.
+    """
     #                 k is Pearson kurtosis.
     grate, mu, sigma, k, yearly, N = gemrat(data, yearly, False)
     b = 2 if b <= 1.0 else b
@@ -319,7 +362,7 @@ def gm2gemrat(data, yearly=256, b=2.5, pc=True):
 
 
 def gm2gem(data, yearly=256, b=2.5, pc=True, n=4):
-    '''Print annualized specs from gm2gemrat() with n decimal places.'''
+    """Print annualized specs from gm2gemrat() with n decimal places."""
     specs = tool.roundit(gm2gemrat(data, yearly, b, pc), n, echo=False)
     print("Geometric  mean rate:", specs[0])
     print("Arithmetic mean rate:", specs[1])

--- a/fecon236/econ/infl.py
+++ b/fecon236/econ/infl.py
@@ -1,6 +1,6 @@
 #  Python Module for import                           Date : 2018-06-17
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-"""Inflation module for fecon236
+"""Inflation module for ``fecon236``
 
 - "Unified" inflation is a sythesis of CPI, CPIc, PCE, PCEc.
 - For derivation of ``foreinfl`` see fecon235/nb/fred-inflation.ipynb,

--- a/fecon236/econ/infl.py
+++ b/fecon236/econ/infl.py
@@ -1,16 +1,21 @@
 #  Python Module for import                           Date : 2018-06-17
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  infl.py :: Inflation module for fecon236
+"""Inflation module for fecon236
 
 - "Unified" inflation is a sythesis of CPI, CPIc, PCE, PCEc.
+- For derivation of ``foreinfl`` see fecon235/nb/fred-inflation.ipynb,
+  which is rendered as https://git.io/infl
 
-- For derivation of foreinfl() see fecon235/nb/fred-inflation.ipynb,
-    which is rendered as https://git.io/infl
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-17  Spin-off foreinfl() from top.py.
-'''
+Change Log
+----------
+
+* 2018-06-17  Spin-off ``foreinfl`` from ``top.py``.
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -23,15 +28,17 @@ from fecon236.dst.gaussmix import gemrat
 
 
 def foreinfl(n=120, alpha=1.0, beta=0.3673):
-    '''Forecast Unified Inflation 1-year ahead per https://git.io/infl
-       which a rendering of fecon235/nb/fred-inflation.ipynb.
-       SUMMARY output: [Average, "infl-date", GMR, HW, BEI]
-       e.g.  [2.2528, '2018-01-01', 1.5793, 3.0791, 2.1000]
-       where Average is the mean of three orthogonal methods:
-       GMR for geometric mean rate, HW for Holt-Winters time-series,
-       and BEI for Break-even Inflation from the Treasury bond market.
-       Default n denotes 120-month history, i.e. last 10 years.
-    '''
+    """Forecast Unified Inflation 1-year ahead
+
+    per https://git.io/infl which a rendering of
+    fecon235/nb/fred-inflation.ipynb.
+
+    output: [Average, "infl-date", GMR, HW, BEI] e.g.  [2.2528, '2018-01-01',
+    1.5793, 3.0791, 2.1000] where Average is the mean of three orthogonal
+    methods: GMR for geometric mean rate, HW for Holt-Winters time-series,
+    and BEI for Break-even Inflation from the Treasury bond market. Default n
+    denotes 120-month history, i.e. last 10 years.
+    """
     #  Holt-Winters parameters alpha and beta are optimized
     #  from the 1960-2018 dataset, consisting of 697 monthly points.
     #  Each "way" is an orthogonal method, to be averaged into way[0].

--- a/fecon236/futures/cftc.py
+++ b/fecon236/futures/cftc.py
@@ -1,19 +1,30 @@
 #  Python Module for import                           Date : 2018-06-17
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  cftc.py :: For futures markets under CFTC
+"""Futures markets under CFTC
 
-- CFTC:= Commodity Futures Trading Commission, a US government agency
-- COTR:= Commitment of Traders Report
+Definitions
+-----------
 
-REFERENCE
+CFTC
+  Commodity Futures Trading Commission, a US government agency
+COTR
+  Commitment of Traders Report
+
+References
+----------
+
 - "Market position indicators using CFTC COTR", https://git.io/cotr
     A fecon235 Jupyter notebook illustrating derivation and usage.
 
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-17  First version: groupcotr() spin-off from util.group module.
-'''
+Change Log
+----------
+
+* 2018-06-17  First version: ``groupcotr`` spin-off from util.group module.
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -32,11 +43,12 @@ cotr4w = {'Bonds': qdl.w4cotr_bonds, 'Equities': qdl.w4cotr_equities,
 
 
 def groupcotr(group=cotr4w, alpha=0):
-    '''Compute latest normalized CFTC COTR position indicators.
-       COTR is the Commitment of Traders Report from US gov agency.
-       Optionally specify alpha for Exponential Moving Average
-       which is a smoothing parameter: 0 < alpha < 1 (try 0.26).
-    '''
+    """Compute latest normalized CFTC COTR position indicators.
+
+    COTR is the Commitment of Traders Report from US gov agency.
+    Optionally specify alpha for Exponential Moving Average
+    which is a smoothing parameter: 0 < alpha < 1 (try 0.26).
+    """
     #  For detailed derivation, see https://git.io/cotr
     positions = groupget(group)
     norpositions = groupfun(tool.normalize, positions)

--- a/fecon236/host/_ex_Quandl.py
+++ b/fecon236/host/_ex_Quandl.py
@@ -61,7 +61,7 @@ try:
 except ImportError:
     from urllib import urlencode  # Python 2
     from urllib2 import HTTPError, Request, urlopen
-    strings = unicode
+    strings = unicode  # noqa: F821
 
 
 # Base API call URL

--- a/fecon236/host/_ex_Quandl.py
+++ b/fecon236/host/_ex_Quandl.py
@@ -1,7 +1,6 @@
 #  Python Module for import                           Date : 2018-05-23
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  _ex_Quandl.py :: fecon236 fork of Quandl API 2.8.9.
+"""fecon236 fork of Quandl API 2.8.9.
 
 Currently supports getting and searching datasets.
 
@@ -12,34 +11,38 @@ https://github.com/quandl/quandl-python/blob/master/2_SERIES_UPGRADE.md
 
 Their version 2.8.9, however, had the virtue of being just a *single* module,
 and has been battle-tested in fecon235 notebooks since 2015-08-03.
-That module has been forked at fecon236 and renamed _ex_Quandl.py.
-The fecon236 qdl module is a wrapper around _ex_Quandl.py.
+That module has been forked at fecon236 and renamed ``_ex_Quandl.py``.
+The fecon236 qdl module is a wrapper around ``_ex_Quandl.py``.
 
 
-REFERENCES:
+References
+----------
 
-- Using Quandl's Python module: https://www.quandl.com/tools/python
+* Using Quandl's Python module: https://www.quandl.com/tools/python
                    GitHub repo: https://github.com/quandl/quandl-python
-
-- Source code for Quandl.py version 2.8.9:
+* Source code for Quandl.py version 2.8.9:
   https://github.com/quandl/quandl-python/blob/v2.8.9/Quandl/Quandl.py
-
-- Complete Quandl API documentation: https://www.quandl.com/docs/api
+* Complete Quandl API documentation: https://www.quandl.com/docs/api
   including error codes.
-
-- RESTful interface introduction:  https://www.quandl.com/help/api
+* RESTful interface introduction:  https://www.quandl.com/help/api
   Not needed here, but it's available for their API version 3.
 
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-05-23  _ex_Quandl.py, fecon236 fork of Quandl.py version 2.8.9.
+Change Log
+----------
+
+* 2018-05-23  _ex_Quandl.py, fecon236 fork of Quandl.py version 2.8.9.
                 Fix over 80 flake8 violations. Pass test_qdl.py.
-2016-04-22  [Ignore newly introduced complex Quandl package version 3.]
-2016-02-23  [Quandl.py API version 2.8.9 removes push() to upload data.]
-2015-08-03  Quandl.py API version 2.8.7 adopted as yi_quandl_api.py
+* 2016-04-22  [Ignore newly introduced complex Quandl package version 3.]
+* 2016-02-23  [Quandl.py API version 2.8.9 removes push() to upload data.]
+* 2015-08-03  Quandl.py API version 2.8.7 adopted as yi_quandl_api.py
                 in fecon235, unchanged and operative through
                 2018-03-12, v5.18.0312, https://git.io/fecon235
-'''
+
+"""
 
 from __future__ import (print_function, division, absolute_import,
                         unicode_literals)
@@ -70,27 +73,43 @@ VERSION = '2.8.7'
 def get(dataset, **kwargs):
     """Return dataframe of requested dataset from Quandl.
 
-    :param dataset: str or list, depending on single or multiset dataset usage
-            Dataset codes are available on the Quandl website
-    :param str authtoken: Downloads are limited to 10 unless token is specified
-    :param str trim_start, trim_end: Optional datefilers, otherwise entire
-           dataset is returned
-    :param str collapse: Options are daily, weekly, monthly, quarterly, annual
-    :param str transformation: options are diff, rdiff, cumul, and normalize
-    :param int rows: Number of rows which will be returned
-    :param str sort_order: options are asc, desc. Default: `asc`
-    :param str returns: specify what format you wish your dataset returned as,
-        either `numpy` for a numpy ndarray or `pandas`. Default: `pandas`
-    :param bool verbose: print output text to stdout? Default is False.
-    :param str text: Deprecated. Use `verbose` instead.
-    :returns: :class:`pandas.DataFrame` or :class:`numpy.ndarray`
+    Parameters
+    ----------
+    dataset: str or list
+        Single or multiset dataset usage. Dataset codes are available on the
+        Quandl website
+    authtoken: str, optional
+        Downloads are limited to 10 unless token is specified
+    trim_start: datefiler, optional
+        Start date
+    trim_end: datefiler, optional
+        End date
+    collapse: str, optional
+        Daily, weekly, monthly, quarterly, annual
+    transformation: str, optional
+        Options are diff, rdiff, cumul, normalize
+    rows: int, optional
+        Number of rows which will be returned
+    sort_order: str, optional
+        Sorting order, `asc` or `desc`. Defaults to `asc`
+    returns: str, optional
+        Dataset output format. Options are `pandas` (default) or `numpy` for
+        an `ndarray`
+    verbose: bool, optional
+        Toggle printing of output text to stdout. Defaults to False.
 
-    Note that Pandas expects timeseries data to be sorted ascending for most
+    Notes
+    -----
+
+    Pandas expects timeseries data to be sorted ascending for most
     timeseries functionality to work.
 
     Any other `kwargs` passed to `get` are sent as field/value params to Quandl
     with no interference.
 
+    Returns
+    -------
+    `pandas.DataFrame` or `numpy.ndarray`
     """
     # Check whether dataset is given as a string (for a single dataset)
     # or an array (for a multiset call)
@@ -184,11 +203,21 @@ def get(dataset, **kwargs):
 def search(query, source=None, page=1, authtoken=None,
            verbose=True, prints=None):
     """Return array of dictionaries of search results.
-    :param str query: (required), query to search with
-    :param str source: (optional), source to search
-    :param +'ve int: (optional), page number of search
-    :param str authotoken: (optional) Quandl auth token for extended API access
-    :returns: :array: search results
+
+    Parameters
+    ----------
+    query: str
+        Query to search with
+    source: str, optional
+        Source to search with
+    page: int, optional
+        Page number to search
+    authtoken: str, optional
+        Quandl auth token for extended API access
+
+    Returns
+    -------
+    `list` search results
     """
     if prints is not None:
         print('Deprecated: "prints", use "verbose" instead.')

--- a/fecon236/host/fred.py
+++ b/fecon236/host/fred.py
@@ -25,7 +25,10 @@ Principal Functions
 Usage
 -----
 
-    >>> df = getfred(fredcode)
+.. code-block:: python
+    :flake8-add-ignore: F821
+
+    df = getfred(fredcode)
 
 References
 ----------

--- a/fecon236/host/fred.py
+++ b/fecon236/host/fred.py
@@ -1,43 +1,55 @@
-#  Python Module for import                           Date : 2018-12-10
+#  Python Module for import                           Date : 2018-05-14
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  fred.py :: FRED database into pandas.
+"""FRED database into pandas.
 
 Functions access data from the Federal Reserve Bank, St. Louis.
 Each economic time series and its frequency has its own "fredcode"
 which is freely available from https://fred.stlouisfed.org
 
-        Usage:  df = getfred(fredcode)
-
 Favorite fredcodes are variables named d4*, m4*, q4*
 which indicate their frequency: daily, monthly, or quarterly.
-
-Principal functions: getfred(), daily(), monthly(), quarterly().
 
 Some series are synthetically created using raw data from FRED.
 Also we may extend their past history, but your working directory
 must contain our supplemental CSV files.
 
-REFERENCES:
 
-- pandas, http://pandas.pydata.org/pandas-docs/stable/computation.html
+Principal Functions
+-------------------
 
-- Wes McKinney, 2013, Python for Data Analysis.
+* ``getfred()``
+* ``daily()``
+* ``monthly()``
+* ``quarterly()``
 
-- Mico Loretan, Federal Reserve Bulletin, Winter 2005,
-       "Indexes of the Foreign Exchange Value of the Dollar",
-       http://www.federalreserve.gov/pubs/bulletin/2005/winter05_index.pdf
+Usage
+-----
 
+    >>> df = getfred(fredcode)
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-12-10  Include more fredcodes for Treasury bonds.
-2018-05-14  Gracefully deprecate plotfred().
-2018-05-13  Eliminate lazy abbreviations, clarify comments.
-2018-05-12  Given new division, eliminate float(integer).
-2018-05-11  Fix imports. Deprecate plotfred().
-2018-05-09  fred.py, fecon236 fork. Pass flake8.
-2018-03-11  yi_fred.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+References
+----------
+
+* Mico Loretan, Federal Reserve Bulletin, Winter 2005, "Indexes of the Foreign
+  Exchange Value of the Dollar",
+  http://www.federalreserve.gov/pubs/bulletin/2005/winter05_index.pdf
+* pandas, http://pandas.pydata.org/pandas-docs/stable/computation.html
+* Wes McKinney, 2013, Python for Data Analysis.
+
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+Change Log
+----------
+
+* 2018-05-14  Gracefully deprecate plotfred().
+* 2018-05-13  Eliminate lazy abbreviations, clarify comments.
+* 2018-05-12  Given new division, eliminate float(integer).
+* 2018-05-11  Fix imports. Deprecate plotfred().
+* 2018-05-09  fred.py, fecon236 fork. Pass flake8.
+* 2018-03-11  yi_fred.py, fecon235 v5.18.0312, https://git.io/fecon235
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -68,18 +80,9 @@ d4libeur = 'EUR3MTD156N'     # 3-m LIBOR EUR, daily
 d4libusd = 'USD3MTD156N'     # 3-m LIBOR USD, daily
 d4ff = 'DFF'                 # Fed Funds, daily since 1954
 d4ff30 = 'd4ff30'            # Fed Funds synthetic, "30-day" exp.mov.avg.
-d4bills = 'DTB3'             # Treasury bills, daily, 1954 (not DGS3MO, 1982)
-
-d4bond1 = 'DGS1'             # Treasury  1-y constant maturity, daily, 1962
-d4bond2 = 'DGS2'             # Treasury  2-y constant maturity, daily, 1976
-d4bond3 = 'DGS3'             # Treasury  3-y constant maturity, daily, 1962
-d4bond5 = 'DGS5'             # Treasury  5-y constant maturity, daily, 1962
-d4bond7 = 'DGS7'             # Treasury  7-y constant maturity, daily, 1969
-d4bond10 = 'DGS10'           # Treasury 10-y constant maturity, daily, 1962
-d4bond20 = 'DGS20'           # Treasury 20-y constant maturity, daily, 1993*
-d4bond30 = 'DGS30'           # Treasury 30-y constant maturity, daily, 1977
-
+d4bills = 'DTB3'             # Treasury bills, daily
 d4zero10 = 'd4zero10'        # Zero-coupon price of Treasury 10-y, daily
+d4bond10 = 'DGS10'           # Treasury 10-y constant, daily
 d4tips10 = 'DFII10'          # TIPS 10-y constant, daily
 d4curve = 'd4curve'          # Treasury 10_y-bills, getfred synthetic
 d4bei = 'd4bei'              # 10_y Break-even inflation, getfred synthetic
@@ -203,10 +206,23 @@ m4unempfr = 'LRHUTTTTFRM156S'  # FR Unemployment rate, OECD SA monthly
 #          make conversions for numerical work later.
 
 def readfile(filename, separator=',', compress=None):
-    '''Read file (CSV default) as pandas dataframe.'''
-    #  If separator is space, use '\s+' since regex will work.
-    #  compress will take 'gzip' or 'bzip' as value.
-    #
+    """
+    Read file (CSV default) as pandas dataframe.
+
+    Parameters
+    ----------
+    filename: str
+        Name of file to be read
+    separator: str, optional
+        Delimiter to use. Defaults to comma (',')
+    compress: str, optional
+        File format for compressed files. 'gzip' and 'bzip' are supported.
+        Defaults to none.
+
+    Notes
+    -----
+    If separator is space, use '\s+' since regex will work.
+    """  # noqa: W605
     dataframe = pd.read_csv(filename, sep=separator,
                             compression=compress,
                             index_col=0, parse_dates=True,
@@ -236,7 +252,14 @@ def readfile(filename, separator=',', compress=None):
 
 
 def makeURL(fredcode):
-    '''Create http address to access FRED's CSV files.'''
+    """
+    Create http address to access FRED's CSV files.
+
+    Parameters
+    ----------
+    fredcode: str
+        FRED series code
+    """
     #         Validated July 2014.
     return 'http://research.stlouisfed.org/fred2/series/' \
         + fredcode + '/downloaddata/' + fredcode + '.csv'
@@ -246,7 +269,14 @@ def makeURL(fredcode):
 #          It's the best primitive to get raw FRED data.
 
 def getdata_fred(fredcode):
-    '''Download CSV file from FRED and read it as pandas DATAFRAME.'''
+    """
+    Download CSV file from FRED and read it as pandas DATAFRAME.
+
+    Parameters
+    ----------
+    fredcode: str
+        FRED series code
+    """
     #  2014-08-11 former name "getdataframe".
     #  2015-12-05 fredcsv = urllib2.urlopen(makeURL(fredcode))
     #                Change import style for python3 compatibility.
@@ -255,7 +285,49 @@ def getdata_fred(fredcode):
 
 
 def index_delta_secs(dataframe):
-    '''Find minimum in seconds between index values.'''
+    """
+    Find minimum in seconds between index values.
+
+    Parameters
+    ----------
+    dataframe: pandas.DataFrame
+
+    Notes
+    -----
+    There are OTHER METHODS to get the FREQUENCY of a dataframe: e.g.
+    ``df.index.freq``  OR  ``df.index.freqstr``, however, these work only
+    if the frequency was attributed: e.g. '1 Hour' OR  'H' respectively.
+    The fecon235 derived dataframes will usually return None.
+
+    Two ``timedelta64`` units, 'Y' years and 'M' months, are
+    specially treated because the time they represent depends upon
+    their context. While a ``timedelta64`` day unit is equivalent to
+    24 hours, there is difficulty converting a month unit into days
+    because months have varying number of days.
+
+    Other ``numpy`` ``timedelta64`` units can be found here:
+    http://docs.scipy.org/doc/numpy/reference/arrays.datetime.html
+
+    For pandas we could do:  ``pd.infer_freq(df.index)`` which, for example,
+    might output 'B' for business daily series.
+
+    But the STRING representation of index frequency is IMPRACTICAL
+    since we may want to compare two unevenly timed indexes.
+    That comparison is BEST DONE NUMERICALLY in some common unit
+    (we use seconds since that is the Unix epoch convention).
+
+    Such comparison will be crucial for the machine
+    to chose whether downsampling or upsampling is appropriate.
+    The casual user should not be expected to know the functions
+    within ``index_delta_secs`` to smoothly work with a notebook.
+
+    See Also
+    --------
+    For details on frequency conversion, see McKinney 2013,
+      Chp. 10 RESAMPLING, esp. Table 10-5 on downsampling.
+      pandas defaults are:  how='mean', closed='right', label='right'
+
+    """
     nanosecs_timedelta64 = np.diff(dataframe.index.values).min()
     #  Picked min() over median() to conserve memory;      ^^^^^!
     #  also avoids missing values issue,
@@ -269,38 +341,7 @@ def index_delta_secs(dataframe):
     else:
         return secs
 
-    #  There are OTHER METHODS to get the FREQUENCY of a dataframe:
-    #       e.g.  df.index.freq  OR  df.index.freqstr ,
-    #  however, these work only if the frequency was attributed:
-    #       e.g.  '1 Hour'       OR  'H'  respectively.
-    #  The fecon235 derived dataframes will usually return None.
-    #
-    #  Two timedelta64 units, 'Y' years and 'M' months, are
-    #  specially treated because the time they represent depends upon
-    #  their context. While a timedelta64 day unit is equivalent to
-    #  24 hours, there is difficulty converting a month unit into days
-    #  because months have varying number of days.
-    #       Other numpy timedelta64 units can be found here:
-    #  http://docs.scipy.org/doc/numpy/reference/arrays.datetime.html
-    #
-    #  For pandas we could do:  pd.infer_freq(df.index)
-    #  which, for example, might output 'B' for business daily series.
-    #
-    #  But the STRING representation of index frequency is IMPRACTICAL
-    #  since we may want to compare two unevenly timed indexes.
-    #  That comparison is BEST DONE NUMERICALLY in some common unit
-    #  (we use seconds since that is the Unix epoch convention).
-    #
-    #  Such comparison will be crucial for the machine
-    #  to chose whether downsampling or upsampling is appropriate.
-    #  The casual user should not be expected to know the functions
-    #  within index_delta_secs() to smoothly work with a notebook.
 
-
-#  For details on frequency conversion, see McKinney 2013,
-#       Chp. 10 RESAMPLING, esp. Table 10-5 on downsampling.
-#       pandas defaults are:  how='mean', closed='right', label='right'
-#
 #  2014-08-10  closed and label to the 'left' conform to FRED practices.
 #              how='median' since it is more robust than 'mean'.
 #  2014-08-14  If upsampling, interpolate() does linear evenly,
@@ -309,10 +350,17 @@ def index_delta_secs(dataframe):
 
 
 def resample_main(dataframe, rule, secs):
-    '''Generalized resample routine for downsampling or upsampling.'''
-    #  rule is the offset string or object representing target conversion,
-    #       e.g. 'B', 'MS', or 'QS-OCT' to be compatible with FRED.
-    #  secs should be the maximum seconds expected for rule frequency.
+    """
+    Generalized resample routine for downsampling or upsampling.
+
+    Parameters
+    ----------
+    rule: str
+        Offset string or object representing target conversion (e.g. 'B', 'MS',
+        or 'QS-OCT' to be compatible with FRED.)
+    secs: int
+        Maximum seconds expected for rule frequency.
+    """
     if index_delta_secs(dataframe) < secs:
         df = dataframe.resample(rule, closed='left', label='left').median()
         #    how='median' for DOWNSAMPLING deprecated as of pandas 0.18
@@ -327,23 +375,53 @@ def resample_main(dataframe, rule, secs):
 
 
 def daily(dataframe):
-    '''Resample data to daily using only business days.'''
-    #                         'D' is used calendar daily
-    #                         'B' for business daily
+    """
+    Resample data to daily using only business days.
+
+    Parameters
+    ----------
+    dataframe: pandas.DataFrame
+        Dataframe to resample
+    """
     secs1day2hours = 93600.0
     return resample_main(dataframe, 'B', secs1day2hours)
 
 
 def monthly(dataframe):
-    '''Resample data to FRED's month start frequency.'''
-    #  FRED uses the start of the month to index its monthly data.
-    #                         'M'  is used for end of month.
-    #                         'MS' for start of month.
+    """
+    Resample data to FRED's month start frequency. FRED uses the start of the
+    month to index its monthly data.
+
+    Parameters
+    ----------
+    dataframe: pandas.DataFrame
+        Dataframe to resample
+    """
     secs31days = 2678400.0
     return resample_main(dataframe, 'MS', secs31days)
 
 
 def quarterly(dataframe):
+    """
+    Resample data to FRED's quarterly start frequency.
+
+    Parameters
+    ----------
+    dataframe: pandas.DataFrame
+        Dataframe to resample
+
+    Notes
+    -----
+    The quarterly data is
+    indexed as follows:
+
+    +----------+----------+-----------+-----------+
+    | Q1       | Q2       | Q3        | Q4        |
+    +----------+----------+-----------+-----------+
+    | 01-01    | 04-01    | 07-01     | 10-01     |
+    +----------+----------+-----------+-----------+
+
+    """
     '''Resample data to FRED's quarterly start frequency.'''
     #  FRED uses the start of the month to index its monthly data.
     #  Then for quarterly data: 1-01, 4-01, 7-01, 10-01.
@@ -356,10 +434,19 @@ def quarterly(dataframe):
 
 
 def getm4eurusd(fredcode=d4eurusd):
-    '''Make monthly EURUSD, and try to prepend 1971-2002 archive.'''
-    #  Synthetic euro is the average between
-    #                 DEM fixed at 1.95583 and
-    #                 FRF fixed at 6.55957.
+    """
+    Make monthly EURUSD, and try to prepend 1971-2002 archive.
+
+    Parameters
+    ----------
+    fredcode: str, optional
+        FRED series code, defaults to "DEXUSEU"
+
+    Notes
+    -----
+    Synthetic euro is the average between DEM fixed at 1.95583 and FRF fixed at
+    6.55957.
+    """
     eurnow = monthly(getdata_fred(fredcode))
     try:
         eurold = readfile('FRED-EURUSD_1971-2002-ARC.csv.gz', compress='gzip')
@@ -373,9 +460,19 @@ def getm4eurusd(fredcode=d4eurusd):
 
 
 def getspx(fredcode=d4spx):
-    '''Make daily S&P 500 series, and try to prepend 1957-archive.'''
-    #  Fred is currently licensed for only 10 years worth,
-    #  however, we have a local copy of 1957-2014 daily data.
+    """
+    Make daily S&P 500 series, and try to prepend 1957-archive.
+
+    Parameters
+    ----------
+    fredcode: str, optional
+        FRED series code, defaults to "SP500"
+
+    Notes
+    -----
+    Fred is currently licensed for only 10 years worth, however, we have a
+    local copy of 1957-2014 daily data.
+    """
     spnow = getdata_fred(fredcode)
     try:
         spold = readfile('FRED-SP500_1957-2014-ARC.csv.gz', compress='gzip')
@@ -389,9 +486,23 @@ def getspx(fredcode=d4spx):
 
 
 def gethomepx(fredcode=m4homepx):
-    '''Make Case-Shiller 20-city, and try to prepend 1987-2000 10-city.'''
-    #  Fred's licensing may change since source is S&P,
-    #  however, we have a local copy of 1987-2013 monthly SA data.
+    """
+    Make Case-Shiller 20-city, and try to prepend 1987-2000 10-city.
+
+    Parameters
+    ----------
+    fredcode: str, optional
+        FRED series code, defaults to helper m4homepx
+
+    Notes
+    -----
+    Fred's licensing may change since source is S&P, however, we have a local
+    copy of 1987-2013 monthly SA data.
+
+    See Also
+    --------
+    m4homepx: Helper function
+    """
     hpnow = getdata_fred('SPCS20RSA')
     #                          20-city home price index back to 2000-01-01.
     try:
@@ -415,9 +526,15 @@ def gethomepx(fredcode=m4homepx):
 
 
 def getinflations(inflations=ml_infl):
-    '''Normalize and average all inflation measures.'''
-    #  We will take the average of indexes after their
-    #  current value is set to 1 for equal weighting.
+    """
+    Normalize and average all inflation measures. Take the average of indexes
+    after their current value is set to 1 for equal weighting.
+
+    Parameters
+    ----------
+    inflations: list
+        List of inflation measures to normalize
+    """
     inflsum = getdata_fred(inflations[0])
     inflsum = inflsum / float(tool.tailvalue(inflsum))
     for i in inflations[1:]:
@@ -428,11 +545,21 @@ def getinflations(inflations=ml_infl):
 
 
 def getdeflator(inflation=m4infl):
-    '''Construct a de-inflation dataframe suitable as multiplier.'''
-    #  Usually we encounter numbers which have been deflated to dollars
-    #  of some arbitrary year (where the value is probably 100).
-    #  Here we set the present to 1, while past values have increasing
-    #     multiplicative "returns" which will yield current dollars.
+    """
+    Construct a de-inflation dataframe suitable as multiplier.
+
+    Parameters
+    ----------
+    inflation: str, optional
+        Inflation data to use, detaults to synthetic inflation
+
+    Notes
+    -----
+    Usually we encounter numbers which have been deflated to dollars
+    of some arbitrary year (where the value is probably 100).
+    Here we set the present to 1, while past values have increasing
+    multiplicative "returns" which will yield current dollars.
+    """
     infl = getfred(inflation)
     lastin = tool.tailvalue(infl)
     return float(lastin) / infl
@@ -440,9 +567,14 @@ def getdeflator(inflation=m4infl):
 
 
 def getm4infleu():
-    '''Normalize and average Eurozone Consumer Prices.'''
-    #  FRED carries only NSA data from Eurostat,
-    #  so we shall use Holt-Winters levels.
+    """
+    Normalize and average Eurozone Consumer Prices.
+
+    Notes
+    -----
+    FRED carries only NSA data from Eurostat,
+    so we shall use Holt-Winters levels.
+    """
     cpiall = getdata_fred('CP0000EZ17M086NEST')
     #                        ^for 17 countries.
     holtall = hw.holtlevel(cpiall)
@@ -458,8 +590,13 @@ def getm4infleu():
 
 
 def getfred(fredcode):
-    '''Retrieve from FRED in dataframe format, INCL. SPECIAL CASES.'''
-    #    We can SYNTHESIZE a FREDCODE by use of string equivalent arg:
+    """
+    Retrieve from FRED in dataframe format, INCL. SPECIAL CASES.
+
+    Notes
+    -----
+    We can SYNTHESIZE a FREDCODE by use of string equivalent arg
+    """
     if fredcode == m4gdpus:
         df = monthly(getdata_fred(q4gdpus))
     elif fredcode == m4gdpusr:
@@ -570,8 +707,11 @@ def getfred(fredcode):
 
 
 def plotfred(data, title='tmp', maxi=87654321):
-    '''DEPRECATED: Plot data should be given as dataframe or fredcode.'''
-    #  ^2018-05-11. Removal OK after 2020-01-01.
+    """
+    .. deprecated:: 0.18.0
+            Plot data should be given as dataframe or fredcode. `plotfred` will
+            be removed on or after 2020-01-01
+    """
     msg = "plotfred() DEPRECATED. Instead use get() and plot()."
     raise DeprecationWarning(msg)
 

--- a/fecon236/host/hostess.py
+++ b/fecon236/host/hostess.py
@@ -1,16 +1,72 @@
 #  Python Module for import                           Date : 2018-06-18
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  hostess.py :: Brings together fecon236 host modules
+"""fecon236 host modules
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-18  Circular dependency HACK [Endnotes]: put imports inside get()
-                and avoid "from" import syntax there. Fix #3
-2018-06-15  Faster get() by exploiting startswith('s4'). Pass flake8.
-                Raised error messaging improved for getstock().
-2018-06-14  Spin-off get() from top.py.
-2018-03-12  fecon235.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Notes
+-----
+* For LATEST version, see https://git.io/fecon236
+
+Circular Dependencies
+~~~~~~~~~~~~~~~~~~~~~
+
+By putting imports within a function we used a technique called
+"DEFERRED IMPORTING." This does not violate Python syntax, as the
+official documentation states:
+
+    "It is customary but not required to place all import statements
+    at the beginning of a module (or script, for that matter)."
+    https://docs.python.org/2/tutorial/modules.html
+
+The downside to deferred imports generally is readability: one
+cannot look at the very top of a module and see all its dependencies.
+
+The official documentation also says that it is advisable to use
+"import X.Y", instead of other statements such as
+"from X import Y", or in the worst case: "from X.Y import *".
+
+As for circular imports, the candidate solutions are explained at
+https://stackoverflow.com/a/37126790 by brendan-abel
+which can be BEST summarized as: use absolute (not relative) imports,
+and definitely AVOID the "from" import style.
+
+The downside to absolute import style is that the names can
+get super long. But one can create aliases using "=" with Python objects,
+especially functions, at the cost of readability. Generally this solution
+across the tops of many modules becomes very tiresome to implement.
+
+"Deferred importing" can speed up startup time, so it is not bad practice,
+but some claim that it is a sign of bad design. The notion that circular
+dependencies are somehow an indication of poor design seems to be more a
+reflection on Python as a language ("glaring bug in the import machinery")
+rather than a legitimate design point.
+
+.. seealso:: http://stackabuse.com/python-circular-imports by Scott Robinson.
+
+
+Example of fecon236 circular dependency
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In the fred module, ``holtwinters.ema`` is called to smooth data.
+In the holtwinters module, ``hostess.get`` is called to retrieve data.
+But the hostess module relies on ``fred.getfred`` in the fred module.
+
+Our deferred import hack in this module, allows us to freely use the
+``from`` syntax everywhere else: e.g. ``from fecon236.host.hostess import get``
+at the top of modules without ``ImportError`` or ``AttributeError`` in both
+python27 and python3.
+
+
+
+Change Log
+----------
+
+* 2018-06-18  Circular dependency HACK [Endnotes]: put imports inside get()
+  and avoid "from" import syntax there. Fix #3
+* 2018-06-15  Faster get() by exploiting startswith('s4'). Pass flake8.
+  Raised error messaging improved for getstock().
+* 2018-06-14  Spin-off get() from top.py.
+* 2018-03-12  fecon235.py, fecon235 v5.18.0312, https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -18,26 +74,34 @@ from fecon236.util import system
 
 
 def get(code, maxi=0):
-    '''Unifies getfred, getqdl, and getstock for data retrieval.
-    code is fredcode, quandlcode, futures slang, or stock slang.
-    maxi should be an integer to set maximum number of data points,
-         where 0 implies the default value.
+    """Unifies getfred, getqdl, and getstock for data retrieval.
 
-    get() will accept the vendor code directly as string, e.g.
-    from FRED and Quandl, or use one of our abbreviated variables
-    documented in the appropriate module listed in the import section.
-    The notebooks provide good code examples in action.
 
     Futures slang is of the form 'f4spotyym' where
-                  spot is the spot symbol in lower case,
-                  yy   is the last two digits of the year
-                  m    is the delivery month code,
-            so for December 2015 COMEX Gold: 'f4xau15z'
+
+    * spot is the spot symbol in lower case,
+    * yy   is the last two digits of the year
+    * m    is the delivery month code,
+
+    so for December 2015 COMEX Gold: 'f4xau15z'
 
     Stock slang can be also used for ETFs and mutual funds.
     The general form is 's4symbol' where the symbol must be in
     lower case, so for SPY, use 's4spy' as an argument.
-    '''
+
+    ``get`` will accept the vendor code directly as string, e.g.
+    from FRED and Quandl, or use one of our abbreviated variables
+    documented in the appropriate module listed in the import section.
+    The notebooks provide good code examples in action.
+
+    Parameters
+    ----------
+    code: str
+        fredcode, quandlcode, futures slang, or stock slang
+    maxi: int
+        Set maximum number of data points, where 0 implies the default value.
+
+    """
     #  Just to avoid long names...
     #  and a verbose way of avoiding "from" import syntax:
     import fecon236.host.fred
@@ -71,54 +135,3 @@ def get(code, maxi=0):
 
 if __name__ == "__main__":
     system.endmodule()
-
-
-# ======================================================== ENDNOTES ===========
-'''
-_______________ On CIRCULAR DEPENDENCIES
-
-By putting imports within a function we used a technique called
-"DEFERRED IMPORTING." This does not violate Python syntax, as the
-official documentation states:
-
-    "It is customary but not required to place all import statements
-    at the beginning of a module (or script, for that matter)."
-    https://docs.python.org/2/tutorial/modules.html
-
-The downside to deferred imports generally is readability: one
-cannot look at the very top of a module and see all its dependencies.
-
-The official documentation also says that it is advisable to use
-"import X.Y", instead of other statements such as
-"from X import Y", or in the worst case: "from X.Y import *".
-
-As for circular imports, the candidate solutions are explained at
-https://stackoverflow.com/a/37126790 by brendan-abel
-which can be BEST summarized as: use absolute (not relative) imports,
-and definitely AVOID the "from" import style.
-
-The downside to absolute import style is that the names can
-get super long. But one can create aliases using "=" with Python objects,
-especially functions, at the cost of readability. Generally this solution
-across the tops of many modules becomes very tiresome to implement.
-
-"Deferred importing" can speed up startup time, so it is not bad practice,
-but some claim that it is a sign of bad design. The notion that circular
-dependencies are somehow an indication of poor design seems to be more a
-reflection on Python as a language ("glaring bug in the import machinery")
-rather than a legitimate design point.
-
-See also: http://stackabuse.com/python-circular-imports by Scott Robinson.
-
-
-     __________ Example of fecon236 circular dependency
-
-In the fred module, holtwinters.ema() is called to smooth data.
-In the holtwinters module, hostess.get() is called to retrieve data.
-But the hostess module relies on fred.getfred() in the fred module.
-
-Our deferred import hack in this module, allows us to freely use the
-"from" syntax everywhere else: e.g. "from fecon236.host.hostess import get"
-at the top of modules without ImportError or AttributeError in both
-python27 and python3.
-'''

--- a/fecon236/host/qdl.py
+++ b/fecon236/host/qdl.py
@@ -1,5 +1,6 @@
 #  Python Module for import                           Date : 2018-05-23
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
+
 """Access Quandl data vendors using fecon236.
 
 We define functions to access data from Quandl.  Each time-series and its
@@ -31,6 +32,9 @@ After creating an account at quandl.com, set your authentication token
 by executing this fecon236 function (described in this module):
 
 .. code-block:: python
+    :flake8-group: Ignore
+
+    import fecon236 as fe
 
     fe.qdl.setQuandlToken(API_key)
 
@@ -129,6 +133,7 @@ Usage
 -----
 
 .. code-block:: python
+    :flake8-add-ignore: F821
 
     df = getqdl(quandlcode)
 
@@ -143,14 +148,16 @@ data series ("pandas") and a numpy array ("numpy"). "pandas" is the default.
 One can specify the format explicitly:
 
 .. code-block:: python
+    :flake8-add-ignore: F821
 
     mydata = fe.qdl._qget("WIKI/AAPL", returns="numpy")
 
 You can get multiple datasets in one call by passing an array of Quandl codes:
 
 .. code-block:: python
+    :flake8-add-ignore: F821
 
-    mydata = fe.qdl._qget(["NSE/OIL.4","WIKI/AAPL.1"])
+    mydata = fe.qdl._qget(["NSE/OIL.4", "WIKI/AAPL.1"])
 
 This grabs the 4th column of dataset NSE/OIL and the 1st column of dataset
 WIKI/AAPL, and returns them in a single call.
@@ -158,6 +165,7 @@ WIKI/AAPL, and returns them in a single call.
 We can manipulate or transform the data prior to download [not advised]:
 
 .. code-block:: python
+    :flake8-add-ignore: F821
 
     #  Specific Date Range:
     mydata = fe.qdl._qget("NSE/OIL", trim_start="yyyy-mm-dd",
@@ -177,6 +185,7 @@ We can manipulate or transform the data prior to download [not advised]:
 A request with a full list of options would look like the following:
 
 .. code-block:: python
+    :flake8-add-ignore: F821
 
     data = fe.qdl._qget('PRAGUESE/PX', authtoken='xxxxxx',
                         trim_start='2001-01-01',
@@ -421,6 +430,7 @@ def fut_decode(slang):
     Our short slang must be in all lower case, e.g.
 
     .. code-block:: python
+        :flake8-add-ignore: F821
 
         print(fut_decode('f4xau15z'))
         # CME/GCZ2015

--- a/fecon236/host/qdl.py
+++ b/fecon236/host/qdl.py
@@ -1,7 +1,6 @@
 #  Python Module for import                           Date : 2018-05-23
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  qdl.py :: Access Quandl data vendors using fecon236.
+"""Access Quandl data vendors using fecon236.
 
 We define functions to access data from Quandl.  Each time-series and its
 frequency has its own "quandlcode" available at: https://www.quandl.com
@@ -12,11 +11,6 @@ grabs the 4th column of NSE/OIL.
 Favorite quandlcodes are variables named d4*, m4*, q4*
 which indicate their frequency: daily, monthly, or quarterly.
 
-USAGE:  df = getqdl(quandlcode)
-
-
-_______________ SYNOPSIS
-
 On 2016-04-22 Quandl released version 3 of their API which was a "drop-in"
 replacement of version 2, but a very complex *package* which has not seen
 any substantive improvement since that date -- see
@@ -24,16 +18,19 @@ https://github.com/quandl/quandl-python/blob/master/2_SERIES_UPGRADE.md
 
 Their version 2.8.7, however, had the virtue of being just a *single* module,
 and has been battle-tested in fecon235 notebooks since 2015-08-03.
-That module has been forked at fecon236 and renamed _ex_Quandl.py.
-This qdl module is a wrapper around _ex_Quandl.py, and
-as of 2018-05-22 has passed tests/test_qdl.py.
+That module has been forked at fecon236 and renamed ``_ex_Quandl.py``.
+This qdl module is a wrapper around ``_ex_Quandl.py``, and
+as of 2018-05-22 has passed `tests/test_qdl.py`.
 
 
-        _____ API Key
+API Key
+-------
 
 You will need an API Key UNLESS you are doing fewer than 50 calls per day.
 After creating an account at quandl.com, set your authentication token
 by executing this fecon236 function (described in this module):
+
+.. code-block:: python
 
     fe.qdl.setQuandlToken(API_key)
 
@@ -43,7 +40,8 @@ so it is unnecessary to enter them more than once, unless you change your
 working directory.
 
 
-        _____ Usage Rules
+Usage Rules
+-----------
 
 API usage is free for registered users. Registered users have a limit of 2,000
 calls per 10 minutes, and a limit of 50,000 calls per day. Premium data
@@ -53,7 +51,8 @@ calls per day.  Dataset calls are rate-limited to 2,000 calls per 10 minutes.
 All API requests must be made using HTTPS. Requests made over HTTP will fail.
 
 
-        _____ Quandl Codes
+Quandl Codes
+------------
 
 To use the API to download a dataset, you will need to know the dataset's
 "quandlcode".  Each dataset on Quandl has a unique Quandl code, comprising a
@@ -66,7 +65,8 @@ is not the same as MCX/CUG2014. You need both the database_code and the
 dataset_code to fully identify a dataset.
 
 
-        _____ Pre-calculations
+Pre-calculations
+----------------
 
 In general, we suggest downloading the data in raw format in the highest
 frequency possible and preforming any data manipulation in pandas itself.
@@ -75,50 +75,80 @@ Quandl allows you to perform certain elementary calculations on your data
 prior to downloading. The transformations currently availabe are row-on-row
 change, percentage change, cumulative sum, and normalize (set starting value
 at 100).  If a datapoint for time t is denoted as y[t] and the transformed
-data as y'[t], the available transformations are defined as below:
+data as y'[t], the available transformations are defined as below.
 
-Transformation      Parameter     Effect
-Row-on-row change   diff          y'[t] = y[t] - y[t-1]
-Row-on-row % change rdiff         y'[t] = (y[t] - y[t-1])/y[t-1]
-Cumulative sum      cumul         y'[t] = y[t] +y[t-1] + ... + y[0]
-Start at 100        normalize     y'[t] = (y[t]/y[0]) * 100
++---------------------+---------------+-----------------------------------+
+| Transformation      | Parameter     | Effect                            |
++=====================+===============+===================================+
+| Row-on-row change   | ``diff``      | y'[t] = y[t] - y[t-1]             |
++---------------------+---------------+-----------------------------------+
+| Row-on-row % change | ``rdiff``     | y'[t] = (y[t] - y[t-1])/y[t-1]    |
++---------------------+---------------+-----------------------------------+
+| Cumulative sum      | ``cumul``     | y'[t] = y[t] +y[t-1] + ... + y[0] |
++---------------------+---------------+-----------------------------------+
+| Start at 100        | ``normalize`` | y'[t] = (y[t]/y[0]) * 100         |
++---------------------+---------------+-----------------------------------+
 
 Note that y[0] in the above table refers to the starting date for the API
 call, i.e., the date specified by trim_start= or rows=, NOT the starting date
 of the entire dataset.
 
 
-        _____ Specific API Guides
+API Guides
+----------
 
-Economics:     https://www.quandl.com/resources/api-for-economic-data
-Stocks:        https://www.quandl.com/resources/api-for-stock-data
-Earnings:      https://www.quandl.com/resources/api-for-earnings-data
-Futures:       https://www.quandl.com/resources/api-for-futures-data
-Currencies:    https://www.quandl.com/resources/api-for-currency-data
-Bitcoin:       https://www.quandl.com/resources/api-for-bitcoin-data
-Commodities:   https://www.quandl.com/resources/api-for-commodity-data
-Housing:       https://www.quandl.com/resources/api-for-housing-data
-International: https://www.quandl.com/resources/api-for-country-data
++---------------+---------------------------------------------------------+
+| Economics     | https://www.quandl.com/resources/api-for-economic-data  |
++---------------+---------------------------------------------------------+
+| Stocks        | https://www.quandl.com/resources/api-for-stock-data     |
++---------------+---------------------------------------------------------+
+| Earnings      | https://www.quandl.com/resources/api-for-earnings-data  |
++---------------+---------------------------------------------------------+
+| Futures       | https://www.quandl.com/resources/api-for-futures-data   |
++---------------+---------------------------------------------------------+
+| Currencies    | https://www.quandl.com/resources/api-for-currency-data  |
++---------------+---------------------------------------------------------+
+| Bitcoin       | https://www.quandl.com/resources/api-for-bitcoin-data   |
++---------------+---------------------------------------------------------+
+| Commodities   | https://www.quandl.com/resources/api-for-commodity-data |
++---------------+---------------------------------------------------------+
+| Housing       | https://www.quandl.com/resources/api-for-housing-data   |
++---------------+---------------------------------------------------------+
+| International | https://www.quandl.com/resources/api-for-country-data   |
++---------------+---------------------------------------------------------+
 
-
-        _____ Contact
+Contact
+-------
 
 Reach out to Quandl for direct support at connect@quandl.com
 Inquires about the Python API package to    Chris@quandl.com
 
 
-    __________ Using low-level API
 
-A fecon236 user would normally just employ high-level wrapper getqdl(),
+Usage
+-----
+
+.. code-block:: python
+
+    df = getqdl(quandlcode)
+
+Low-level API
+~~~~~~~~~~~~~
+
+A `fecon236` user would normally just employ high-level wrapper getqdl(),
 not _qget(), but for the developer the following may be interesting:
 
 The module named as quandlapi is able to return data in 2 formats: a pandas
 data series ("pandas") and a numpy array ("numpy"). "pandas" is the default.
 One can specify the format explicitly:
 
+.. code-block:: python
+
     mydata = fe.qdl._qget("WIKI/AAPL", returns="numpy")
 
 You can get multiple datasets in one call by passing an array of Quandl codes:
+
+.. code-block:: python
 
     mydata = fe.qdl._qget(["NSE/OIL.4","WIKI/AAPL.1"])
 
@@ -126,6 +156,8 @@ This grabs the 4th column of dataset NSE/OIL and the 1st column of dataset
 WIKI/AAPL, and returns them in a single call.
 
 We can manipulate or transform the data prior to download [not advised]:
+
+.. code-block:: python
 
     #  Specific Date Range:
     mydata = fe.qdl._qget("NSE/OIL", trim_start="yyyy-mm-dd",
@@ -144,45 +176,47 @@ We can manipulate or transform the data prior to download [not advised]:
 
 A request with a full list of options would look like the following:
 
-data = fe.qdl._qget('PRAGUESE/PX', authtoken='xxxxxx', trim_start='2001-01-01',
-                    trim_end='2010-01-01', collapse='annual',
-                    transformation='rdiff', rows=4, returns='numpy')
+.. code-block:: python
+
+    data = fe.qdl._qget('PRAGUESE/PX', authtoken='xxxxxx', trim_start='2001-01-01',
+                        trim_end='2010-01-01', collapse='annual',
+                        transformation='rdiff', rows=4, returns='numpy')
 
 
-        _____ Low-level push() [deprecated in Quandl API 2.8.9]
+References
+----------
 
-You can no longer upload your own data to Quandl using version 2.
-
-
-REFERENCES:
-
-- Using Quandl's Python module: https://www.quandl.com/help/python
+* Using Quandl's Python module: https://www.quandl.com/help/python
                    GitHub repo: https://github.com/quandl/quandl-python
-
-- Complete Quandl API documentation: https://www.quandl.com/docs/api
+* Complete Quandl API documentation: https://www.quandl.com/docs/api
   including error codes.
-
-- [RESTful interface introduction:  https://www.quandl.com/help/api
+* [RESTful interface introduction:  https://www.quandl.com/help/api
     Not needed here, but it's available for their API version 3.]
-
-- CFTC Commitments of Traders Report, explanatory notes:
+* CFTC Commitments of Traders Report, explanatory notes:
   http://www.cftc.gov/MarketReports/CommitmentsofTraders/ExplanatoryNotes
-
     - Traders' option positions are computed on a futures-equivalent basis
        using delta factors supplied by the exchanges.
-
-- Computational tools for pandas
+* Computational tools for pandas
        http://pandas.pydata.org/pandas-docs/stable/computation.html
+* Wes McKinney, 2013, _Python for Data Analysis_.
 
-- Wes McKinney, 2013, _Python for Data Analysis_.
+
+Notes
+-----
+* For LATEST version, see https://git.io/fecon236
+* Low-level push() [deprecated in Quandl API 2.8.9]
+* You can no longer upload your own data to Quandl using version 2.
 
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-05-23  qdl.py, fecon236 fork. Edit intro. Pass flake8 and test_qdl.
+Change Log
+----------
+
+* 2018-05-23  qdl.py, fecon236 fork. Edit intro. Pass flake8 and test_qdl.
                 Fix imports. Deprecate plotqdl() and holtqdl.
                 Rename quandl() as _qget() for future clarity.
-2017-02-07  yi_quandl.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+* 2017-02-07  yi_quandl.py, fecon235 v5.18.0312, https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -238,9 +272,13 @@ m4spx_1871_d = 'm4spx_1871_d'    # Shiller S&P500 nominal dividends 12-month
 
 
 def setQuandlToken(API_key):
-    '''Generate authtoken.p in the local directory for API access.'''
-    #  Must have API key which is free by creating a Quandl account,
-    #  however, this is not necessary for limited usage.
+    """Generate authtoken.p in the local directory for API access.
+
+    Notes
+    -----
+    Must have API key which is free by creating a Quandl account,
+    however, this is not necessary for limited usage.
+    """
     _ = _qget("NSE/OIL", authtoken=API_key, rows=1)   # noqa
     #  This dummy request creates your token file "authtoken.p"
     #  in your current working directory.
@@ -253,22 +291,30 @@ def setQuandlToken(API_key):
 
 
 def cotr_get(futures='GC', type='FO'):
-    '''Get CFTC Commitment of Traders Report COTR.'''
-    #  Report for futures only requested by type "F".
-    #  Report for both futures and options requested by type "FO".
-    #  e.g. 'CFTC/GC_FO_ALL' for CFTC COTR: Gold futures and options.
-    #
-    #  Traders' option positions are computed on a futures-equivalent basis
-    #  using delta factors supplied by the exchanges.
+    """Get CFTC Commitment of Traders Report COTR.
+
+    Notes
+    -----
+
+    Report for futures only requested by type "F".
+    Report for both futures and options requested by type "FO".
+    e.g. 'CFTC/GC_FO_ALL' for CFTC COTR: Gold futures and options.
+
+    Traders' option positions are computed on a futures-equivalent basis
+    using delta factors supplied by the exchanges.
+    """
     quandlcode = 'CFTC/' + futures + '_' + type + '_ALL'
     return _qget(quandlcode)
 
 
 def cotr_position(futures='GC'):
-    '''Extract market position from CFTC Commitment of Traders Report.'''
+    """Extract market position from CFTC Commitment of Traders Report.
+
+    Notes
+    -----
+    Report for both futures and options requested by implicit "FO".
+    """
     cotr = cotr_get(futures)
-    #  Report for both futures and options requested by implicit "FO".
-    #
     #  For directionality we use these categories:
     try:
         longs = cotr['Asset Manager Longs']
@@ -286,7 +332,7 @@ def cotr_position(futures='GC'):
 
 
 def cotr_position_usd():
-    '''Market position for USD from COTR of JY and EC.'''
+    """Market position for USD from COTR of JY and EC."""
     #  We ignore USD index DX from ICE.
     pos1 = cotr_position('JY')
     #                      JPY futures.
@@ -299,7 +345,7 @@ def cotr_position_usd():
 
 
 def cotr_position_metals():
-    '''Market position for precious metals from COTR of GC and SI.'''
+    """Market position for precious metals from COTR of GC and SI."""
     pos1 = cotr_position('GC')
     #                      Gold Comex
     pos2 = cotr_position('SI')
@@ -310,7 +356,7 @@ def cotr_position_metals():
 
 
 def cotr_position_bonds():
-    '''Market position for bonds from COTR of TY and ED.'''
+    """Market position for bonds from COTR of TY and ED."""
     pos1 = cotr_position('TY')
     #                      TY is 10-years.
     pos2 = cotr_position('ED')
@@ -321,7 +367,7 @@ def cotr_position_bonds():
 
 
 def cotr_position_equities():
-    '''Market position for equities from COTR of both SP and ES.'''
+    """Market position for equities from COTR of both SP and ES."""
     pos1 = cotr_position('SP')
     #                      SP better for options reading.
     pos2 = cotr_position('ES')
@@ -359,20 +405,26 @@ fut_dict = {
 
 
 def fut_decode(slang):
-    '''Validate and translate slang string into vendor futures code.
+    """Validate and translate slang string into vendor futures code.
 
-    Quandl uses format: {EXCHANGE}/{CODE}{MONTH}{YEAR}
-         {EXCHANGE} is the acronym for the futures exchange
-         {CODE} is the futures ticker code
-         {MONTH} is the single-letter month code
-         {YEAR} is a 4-digit year
+    Quandl uses format: ``{EXCHANGE}/{CODE}{MONTH}{YEAR}``
+         ``{EXCHANGE}`` is the acronym for the futures exchange
+         ``{CODE}`` is the futures ticker code
+         ``{MONTH}`` is the single-letter month code
+         ``{YEAR}`` is a 4-digit year
     So for COMEX Gold Dec 2015: 'CME/GCZ2015' [note: CAPITALIZATION]
 
-    !!  Our short slang must be in all lower case, e.g.
+    Notes
+    -----
 
-    >>> print(fut_decode('f4xau15z'))
-    CME/GCZ2015
-    '''
+    Our short slang must be in all lower case, e.g.
+
+    .. code-block:: python
+
+        print(fut_decode('f4xau15z'))
+        # CME/GCZ2015
+
+    """
     if slang.isupper():
         #  So if given argument is in all CAPS...
         raise ValueError('Futures slang argument is invalid.')
@@ -393,7 +445,7 @@ def fut_decode(slang):
 
 
 def getfut(slang, maxi=512, col='Settle'):
-    '''slang string retrieves single column for one futures contract.
+    """slang string retrieves single column for one futures contract.
 
     The string consists of a key from fut_dict concatenated with
     'yym' where yy is shorthand for year and m is the month symbol
@@ -401,10 +453,16 @@ def getfut(slang, maxi=512, col='Settle'):
 
     Available col are: Open, High, Low, Last, Change, Settle,
                         Volume, 'Open Interest'
-    '''
-    #  Other than Eurodollars, we should not need more than 512 days
-    #  of data due to finite life of a futures contract.
-    #  2015-09-11  quandl default seems to be maxi around 380.
+
+    Notes
+    -----
+
+    * Other than Eurodollars, we should not need more than 512 days of data due
+    to finite life of a futures contract.
+    * 2015-09-11  quandl default seems to be maxi around 380.
+
+    """
+
     #
     fut = _qget(fut_decode(slang), rows=maxi)
     #      return just a single column dataframe:
@@ -433,9 +491,13 @@ def getfut(slang, maxi=512, col='Settle'):
 
 
 def freqM2MS(dataframe):
-    '''Change Monthly dates to (FRED-compatible) Month Start frequency.'''
-    #  FRED uses first day of month 'MS' to index that month's data,
-    #  whereas Quandl data *may* use varying end of month dates.
+    """Change Monthly dates to (FRED-compatible) Month Start frequency.
+
+    Notes
+    -----
+    FRED uses first day of month 'MS' to index that month's data, whereas
+    Quandl data *may* use varying end of month dates.
+    """
     df = dataframe.set_index(pd.DatetimeIndex(
                              [i.replace(day=1) for i in dataframe.index]))
     df.index = df.index.normalize()
@@ -453,7 +515,7 @@ def freqM2MS(dataframe):
 
 
 def getm4spx_1871_p():
-    '''Retrieve nominal monthly Shiller S&P500 price, starting 1871.'''
+    """Retrieve nominal monthly Shiller S&P500 price, starting 1871."""
     price = freqM2MS(_qget('MULTPL/SP500_REAL_PRICE_MONTH'))
     #                           ^But they meant NOMINAL!
     #  Their inflation-adjusted monthly series is called
@@ -463,7 +525,7 @@ def getm4spx_1871_p():
 
 
 def getm4spx_1871_e():
-    '''Retrieve nominal monthly Shiller S&P500 earnings, starting 1871.'''
+    """Retrieve nominal monthly Shiller S&P500 earnings, starting 1871."""
     ratio = freqM2MS(_qget('MULTPL/SP500_PE_RATIO_MONTH'))
     #  Gets price/earnings ratio, so solve for 12-month earnings.
     #  Alternative: official YALE/SPCOMP, but 9 months latency!
@@ -473,7 +535,7 @@ def getm4spx_1871_e():
 
 
 def getm4spx_1871_d():
-    '''Retrieve nominal monthly Shiller S&P500 dividends, starting 1871.'''
+    """Retrieve nominal monthly Shiller S&P500 dividends, starting 1871."""
     dyield = freqM2MS(_qget('MULTPL/SP500_DIV_YIELD_MONTH'))
     #  Gets dividend yield in percentage form,
     #  but we want just plain dividends over previous 12 months.
@@ -484,13 +546,17 @@ def getm4spx_1871_d():
 
 
 def getqdl(quandlcode, maxi=87654321):
-    '''Retrieve from Quandl in dataframe format, INCL. SPECIAL CASES.
-            maxi is just arbitrarily large as default,
-                 useful to limit data to last maxi rows,
-                 e.g. maxi=1 for most recent row only,
-                 but NOT used in all cases below.
-    We can SYNTHESIZE a quandlcode by use of string equivalent arg.
-    '''
+    """Retrieve from Quandl in dataframe format, INCL. SPECIAL CASES.
+
+    Notes
+    -----
+
+    * ``maxi`` is just arbitrarily large as default, useful to limit data to
+      last maxi rows, e.g. maxi=1 for most recent row only, but NOT used in all
+      cases below.
+    * We can SYNTHESIZE a quandlcode by use of string equivalent arg.
+
+    """
     if quandlcode == w4cotr_xau:
         df = cotr_position(f4xau)
     elif quandlcode == w4cotr_metals:
@@ -527,14 +593,14 @@ def getqdl(quandlcode, maxi=87654321):
 
 
 def plotqdl(data, title='tmp', maxi=87654321):
-    '''DEPRECATED: Plot data should be it given as dataframe or quandlcode.'''
+    """DEPRECATED: Plot data should be it given as dataframe or quandlcode."""
     #  ^2018-05-22. Removal OK after 2020-01-01.
     msg = "plotqdl() DEPRECATED. Instead use get() and plot()."
     raise DeprecationWarning(msg)
 
 
 def holtqdl(data, h=24, alpha=0.26, beta=0.19):
-    '''DEPRECATED: Holt-Winters forecast h-periods ahead (quandlcode aware).'''
+    """DEPRECATED: Holt-Winters forecast h-periods ahead (quandlcode aware)."""
     #  ^2018-05-22. Removal OK after 2020-01-01.
     msg = "holtqdl() DEPRECATED. Instead use get(), holt(), holtforecast()."
     raise DeprecationWarning(msg)

--- a/fecon236/host/qdl.py
+++ b/fecon236/host/qdl.py
@@ -178,7 +178,8 @@ A request with a full list of options would look like the following:
 
 .. code-block:: python
 
-    data = fe.qdl._qget('PRAGUESE/PX', authtoken='xxxxxx', trim_start='2001-01-01',
+    data = fe.qdl._qget('PRAGUESE/PX', authtoken='xxxxxx',
+                        trim_start='2001-01-01',
                         trim_end='2010-01-01', collapse='annual',
                         transformation='rdiff', rows=4, returns='numpy')
 

--- a/fecon236/host/qdl.py
+++ b/fecon236/host/qdl.py
@@ -200,15 +200,15 @@ References
                    GitHub repo: https://github.com/quandl/quandl-python
 * Complete Quandl API documentation: https://www.quandl.com/docs/api
   including error codes.
-* [RESTful interface introduction:  https://www.quandl.com/help/api
-    Not needed here, but it's available for their API version 3.]
+* RESTful interface introduction:  https://www.quandl.com/help/api
+  Not needed here, but it's available for their API version 3.
 * CFTC Commitments of Traders Report, explanatory notes:
   http://www.cftc.gov/MarketReports/CommitmentsofTraders/ExplanatoryNotes
     - Traders' option positions are computed on a futures-equivalent basis
        using delta factors supplied by the exchanges.
 * Computational tools for pandas
        http://pandas.pydata.org/pandas-docs/stable/computation.html
-* Wes McKinney, 2013, _Python for Data Analysis_.
+* Wes McKinney, 2013, *Python for Data Analysis*.
 
 
 Notes

--- a/fecon236/host/stock.py
+++ b/fecon236/host/stock.py
@@ -25,7 +25,8 @@ References
 ----------
 
 * ``pandas``, http://pandas.pydata.org/pandas-docs/stable/computation.html
-* ``pandas-datareader``: https://pydata.github.io/pandas-datareader/stable/index.html
+* ``pandas-datareader``:
+  https://pydata.github.io/pandas-datareader/stable/index.html
 
 .. warning:: Package name is ``pandas-datareader``, but it is imported under
    the ``pandas_datareader`` module name.

--- a/fecon236/host/stock.py
+++ b/fecon236/host/stock.py
@@ -1,34 +1,51 @@
 #  Python Module for import                           Date : 2018-06-04
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  stock.py :: Access stock quotes for fecon236
+"""Access stock quotes for fecon236
 
 Functions here are designed to access stock quotes FREELY.
 Vendors of choice have been Yahoo Finance or Google Finance,
 but given disruptions since late 2017, we consider alternates;
 see https://github.com/rsvp/fecon235/issues/7 for details.
 
-        Usage:  df = getstock('s4code', 7)
-                #                       ^one week.
-                #             ^begin with s4, then
-                #              append stock SYMBOL in lower case.
+Usage
+-----
 
- Dependencies:  pandas-datareader (for pandas>=0.17)
+.. code-block:: python
 
-REFERENCES
-- pandas, http://pandas.pydata.org/pandas-docs/stable/computation.html
-- pandas-datareader,
-  https://pydata.github.io/pandas-datareader/stable/index.html
-      ATTN: Package name is "pandas-datareader", but it is
-         imported under the "pandas_datareader" module name.
-- Wes McKinney, 2013, Python for Data Analysis.
+    df = getstock('s4code', 7)
+    #                       ^one week.
+    #             ^begin with s4, then
+    #              append stock SYMBOL in lower case.
 
+Dependencies
+------------
+``pandas-datareader`` (for ``pandas`` >=0.17)
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-05-23  Rename to stock.py, fecon236 fork. Fix imports, pass flake8.
-2017-02-06  yi_stocks.py, fecon235 v5.18.0312, https://git.io/fecon235
-                pandas<=0.17 supported in fecon235.
-'''
+References
+----------
+
+* ``pandas``, http://pandas.pydata.org/pandas-docs/stable/computation.html
+* ``pandas-datareader``: https://pydata.github.io/pandas-datareader/stable/index.html
+
+.. warning:: Package name is ``pandas-datareader``, but it is imported under
+   the ``pandas_datareader`` module name.
+
+* Wes McKinney, 2013, Python for Data Analysis.
+
+Notes
+-----
+
+For LATEST version, see https://git.io/fecon236
+
+Change Log
+----------
+
+* 2018-05-23  Rename to ``stock.py``, ``fecon236`` fork. Fix imports, pass
+  flake8.
+* 2017-02-06  ``yi_stocks.py``, fecon235 v5.18.0312, https://git.io/fecon235
+  ``pandas`` <=0.17 supported in ``fecon235``.
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -43,12 +60,13 @@ s4spx = 's4spy'            # Largest S&P500 ETF.
 
 
 def stock_decode(slang):
-    '''Validate and translate slang string into vendor stock code.
-       Our short slang must be in all lower case starting with s4,
-       e.g. 's4spy' with SYMBOL in lower case.
+    """Validate and translate slang string into vendor stock code.
 
-       Using slang helps to avoid collision in our larger namespace.
-    '''
+    Our short slang must be in all lower case starting with s4, e.g. 's4spy'
+    with SYMBOL in lower case.
+
+    Using slang helps to avoid collision in our larger namespace.
+    """
     if slang.isupper() or slang[:2] != 's4':
         #  So if given argument is in all CAPS,
         #  or does not begin with 's4'
@@ -62,13 +80,13 @@ def stock_decode(slang):
 
 
 def stock_all(slang, maxi=3650):
-    '''slang string retrieves ALL columns for single stock.
+    """slang string retrieves ALL columns for single stock.
 
     The slang string consists of 's4' + symbol, all in lower case,
     e.g. 's4spy' for SPY.
 
-    maxi is set to default of ten years past data.
-    '''
+   ``maxi`` is set to default of ten years past data.
+    """
     #       Typical:  start = datetime.datetime(2013, 1, 20)
     #       but we just want the most current window of data.
     now = datetime.datetime.now()
@@ -90,19 +108,23 @@ def stock_all(slang, maxi=3650):
 
 
 def stock_one(slang, maxi=3650, col='Close'):
-    '''slang string retrieves SINGLE column for said stock.
-        Available col include: Open, High, Low, Close, Volume
-    '''
+    """slang string retrieves SINGLE column for said stock.
+
+    Available col include: Open, High, Low, Close, Volume
+
+    """
     df = stock_all(slang, maxi)
     #      return just a single column dataframe:
     return tool.todf(df[[col]])
 
 
 def getstock(slang, maxi=3650):
-    '''Retrieve stock data from Yahoo Finance or Google Finance.
-    maxi is the number of chronological, not trading, days.
+    """Retrieve stock data from Yahoo Finance or Google Finance.
+
+    ``maxi`` is the number of chronological, not trading, days.
+
     We can SYNTHESIZE a s4 slang by use of string equivalent arg.
-    '''
+    """
     if False:
         pass
     elif False:

--- a/fecon236/host/stock.py
+++ b/fecon236/host/stock.py
@@ -12,6 +12,8 @@ Usage
 
 .. code-block:: python
 
+    from fecon236.host.stock import getstock
+
     df = getstock('s4code', 7)
     #                       ^one week.
     #             ^begin with s4, then

--- a/fecon236/math/matrix.py
+++ b/fecon236/math/matrix.py
@@ -80,6 +80,9 @@ def is_singular(mat):
 
     .. code-block:: python
 
+        import numpy as np
+        import sys
+
         np.finfo(np.float32).eps
         # 1.1920929e-07
         sys.float_info.epsilon

--- a/fecon236/math/matrix.py
+++ b/fecon236/math/matrix.py
@@ -1,39 +1,51 @@
 #  Python Module for import                           Date : 2018-06-16
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  matrix.py :: Linear algebra module
+"""Linear algebra
 
-USAGE:  To easily invert a matrix, use invert() which includes testing
+Usage
+-----
+To easily invert a matrix, use ``invert`` which includes testing
 for ill-conditioned matrix and fallback to computing the Moore-Penrose
 pseudo-inverse.
 
-!!=>  IRONY:  For numpy work, we want to DISCOURAGE the use of np.matrix,
-              which is a subclass of np.ndarray, since their
-              interoperations may produce unexpected results.
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
 
-              - The np.matrix subclass is confined to 2-D matrices.
-              - Sticking with array constructs:
-                  Operator "*" means element-wise multiplication.
-                  For MATRIX MULTIPLICATION, using ".dot()" is BEST,
-                  since operator "@" originates from Python 3.5.
-              - For our arguments, "mat" is mathematically a matrix,
-                  but not necessarily designed for subclass np.matrix.
-              - We explicitly AVOID np.matrix.I to calculate inverse.
-              - We will ASSUME matrices are of TYPE np.ndarray.
+For numpy work, we want to DISCOURAGE the use of ``np.matrix``,
+which is a subclass of ``np.ndarray``, since their
+interoperations may produce unexpected results.
 
-Tests:  See tests/test_matrix.py, esp. for output examples.
+- The ``np.matrix`` subclass is confined to 2-D matrices.
+- Sticking with array constructs:
+  Operator ``*`` means element-wise multiplication.
+  For MATRIX MULTIPLICATION, using ``.dot`` is BEST,
+  since operator ``@`` originates from Python 3.5.
+- For our arguments, ``mat`` is mathematically a matrix,
+  but not necessarily designed for subclass ``np.matrix``.
+- We explicitly AVOID ``np.matrix.I`` to calculate inverse.
+- We will ASSUME matrices are of TYPE ``np.ndarray``.
 
-REFERENCES
+Tests
+-----
+See ``tests/test_matrix.py``, esp. for output examples.
+
+References
+----------
+
 - numpy, https://docs.scipy.org/doc/numpy-dev/user/quickstart.html
 - Gilbert Strang, 1980, Linear Algebra and Its Applications, 2nd ed.
 - Gene H. Golub, 1989, Matrix Computations, 2nd. ed.
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-16  Bring covdiflog() from util.group module.
-2018-06-13  Appropriate error message for invert_caution().
-2018-06-12  matrix.py, fecon236 fork. Fix imports, pass flake8.
-2017-06-19  yi_matrix.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-06-16  Bring ``covdiflog`` from ``util.group`` module.
+* 2018-06-13  Appropriate error message for ``invert_caution``.
+* 2018-06-12  ``matrix.py``, ``fecon236`` fork. Fix imports, pass flake8.
+* 2017-06-19  ``yi_matrix.py``, fecon235 v5.18.0312, https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -47,27 +59,37 @@ RCOND = 1e-15
 
 
 def is_singular(mat):
-    '''Just test whether matrix is singular (thus not invertible).
-       Mathematically, iff det(mat)==0: NOT recommended numerically.
-       If the condition number is very large, then the matrix is said to
-       be "ill-conditioned." Practically such a matrix is almost singular,
-       and the computation of its inverse, or solution of a linear system
-       of equations is prone to large numerical errors.
-       A matrix that is not invertible has condition number equal to
-       infinity mathematically, but here for numerical purposes,
-       "ill-conditioned" shall mean condition number exceeds 1/epsilon.
-    '''
-    #  Ref: https://en.wikipedia.org/wiki/Condition_number
-    #  We shall use epsilon for np.float64 data type
-    #  since Python’s floating-point numbers are usually 64-bit.
-    #      >>> np.finfo(np.float32).eps
-    #      1.1920929e-07
-    #      >>> sys.float_info.epsilon
-    #      2.220446049250313e-16
-    #      >>> np.finfo(np.float64).eps
-    #      2.2204460492503131e-16
-    #      >>> 1/np.finfo(np.float64).eps
-    #      4503599627370496.0
+    """Just test whether matrix is singular (thus not invertible).
+
+    Mathematically, ``if det(mat)==0:`` NOT recommended numerically.
+    If the condition number is very large, then the matrix is said to
+    be "ill-conditioned." Practically such a matrix is almost singular,
+    and the computation of its inverse, or solution of a linear system
+    of equations is prone to large numerical errors.
+    A matrix that is not invertible has condition number equal to
+    infinity mathematically, but here for numerical purposes,
+    "ill-conditioned" shall mean condition number exceeds 1/epsilon.
+
+    Notes
+    -----
+
+    Ref: https://en.wikipedia.org/wiki/Condition_number
+
+    We shall use epsilon for np.float64 data type
+    since Python’s floating-point numbers are usually 64-bit.
+
+    .. code-block:: python
+
+        np.finfo(np.float32).eps
+        # 1.1920929e-07
+        sys.float_info.epsilon
+        # 2.220446049250313e-16
+        np.finfo(np.float64).eps
+        # 2.2204460492503131e-16
+        1/np.finfo(np.float64).eps
+        # 4503599627370496.0
+
+    """
     if np.linalg.cond(mat) < 1 / np.finfo(np.float64).eps:
         #       ^2-norm, computed directly using the SVD.
         return False
@@ -77,13 +99,14 @@ def is_singular(mat):
 
 
 def invert_caution(mat):
-    '''Compute the multiplicative inverse of a matrix.
-       Numerically np.linalg.inv() is generally NOT suitable,
-       especially if the matrix is ill-conditioned,
-       but it executes faster than invert_pseudo():
-       np.linalg.inv() calls numpy.linalg.solve(mat, I)
-       where I is identity and uses LAPACK LU FACTORIZATION.
-    '''
+    """Compute the multiplicative inverse of a matrix.
+
+    Numerically ``np.linalg.inv`` is generally NOT suitable,
+    especially if the matrix is ill-conditioned,
+    but it executes faster than ``invert_pseudo``:
+    ``np.linalg.inv`` calls ``numpy.linalg.solve(mat, I)``
+    where ``I`` is identity and uses LAPACK LU FACTORIZATION.
+    """
     #  Curiously np.linalg.inv() does not test this beforehand:
     if is_singular(mat):
         raise ValueError("SINGULAR matrix here is fatal. Try invert().")
@@ -93,19 +116,28 @@ def invert_caution(mat):
 
 
 def invert_pseudo(mat, rcond=RCOND):
-    '''Compute the pseudo-inverse of a matrix.
-       If a matrix is invertible, its pseudo-inverse will be its inverse.
-       Moore-Penrose algorithm here uses SINGULAR-VALUE DECOMPOSITION (SVD).
-    '''
-    #  Ref: https://en.wikipedia.org/wiki/Moore–Penrose_pseudoinverse
-    #  Mathematically, pseudo-inverse (a.k.a. generalized inverse) is defined
-    #  and unique for all matrices whose entries are real or complex numbers.
-    #         LinAlgError if SVD computation does not converge.
+    """Compute the pseudo-inverse of a matrix.
+
+    If a matrix is invertible, its pseudo-inverse will be its inverse.
+    Moore-Penrose algorithm here uses SINGULAR-VALUE DECOMPOSITION (SVD).
+
+    Notes
+    -----
+    Mathematically, pseudo-inverse (a.k.a. generalized inverse) is defined
+    and unique for all matrices whose entries are real or complex numbers.
+    LinAlgError if SVD computation does not converge.
+
+    References
+    ----------
+
+    * https://en.wikipedia.org/wiki/Moore–Penrose_pseudoinverse
+
+    """
     return np.linalg.pinv(mat, rcond)
 
 
 def invert(mat, rcond=RCOND):
-    '''Compute the inverse, or pseudo-inverse as fallback, of a matrix.'''
+    """Compute the inverse, or pseudo-inverse as fallback, of a matrix."""
     try:
         #  Faster version first, with is_singular() test...
         return invert_caution(mat)
@@ -117,9 +149,10 @@ def invert(mat, rcond=RCOND):
 
 
 def covdiflog(groupdf, lags=1):
-    '''Covariance array for differenced log(column) from group dataframe.
-       For correlation array, feed output here to cov2cor().
-    '''
+    """Covariance array for differenced log(column) from group dataframe.
+
+    For correlation array, feed output here to ``cov2cor``.
+    """
     #  See util.group.groupget() to retrieve and create group dataframe.
     rates = groupdiflog(groupdf, lags)
     V = rates.cov()
@@ -129,10 +162,18 @@ def covdiflog(groupdf, lags=1):
 
 
 def cov2cor(cov, n=6):
-    '''Covariance array to correlation array, n-decimal places.
-       Outputs "Pearson product-moment CORRELATION COEFFICIENTS."
-    '''
-    #  https://en.wikipedia.org/wiki/Covariance_matrix
+    """Covariance array to correlation array, n-decimal places.
+
+    Returns
+    -------
+    Pearson product-moment CORRELATION COEFFICIENTS.
+
+    References
+    ----------
+
+    * https://en.wikipedia.org/wiki/Covariance_matrix
+
+    """
     darr = np.diagonal(cov)
     #        ^get diagonal elements of cov into a pure array.
     #         Numpy docs says darr is not writeable, OK.

--- a/fecon236/ml/learn.py
+++ b/fecon236/ml/learn.py
@@ -68,6 +68,8 @@ def softmax(it, temp=55, n=4):
 
     .. code-block:: python
 
+        from fecon236.ml.learn import softmax_sort
+
         softmax_sort([-16, -8, 0, 4, 8, 16], temp=50, drop=0.05, renorm=False)
         # [(0.5733, 5, 16.0), (0.2019, 4, 8.0), (0.1198, 3, 4.0), (0.0711, 2,
         #  0.0)]

--- a/fecon236/ml/learn.py
+++ b/fecon236/ml/learn.py
@@ -112,8 +112,6 @@ def softmax(it, temp=55, n=4):
     return [idmax, hardmax, hardprob, temp, softmax_approx]
 
 
-
-
 def softmax_sort(it, temp=55, n=4, drop=0.00, renorm=False):
     """Softmax results sorted, include index; option to drop and renormalize.
 

--- a/fecon236/ml/learn.py
+++ b/fecon236/ml/learn.py
@@ -1,23 +1,34 @@
 #  Python Module for import                           Date : 2018-06-13
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  learn.py :: Fundamentals from Machine Learning
+"""Fundamentals from Machine Learning
 
-- softmax() for cross-entropy, MLE, neural networks, Boltzmann portfolio.
-- softmax_sort() for ordering and filtering info on the probabilities.
+- ``softmax`` for cross-entropy, MLE, neural networks, Boltzmann portfolio.
+- ``softmax_sort`` for ordering and filtering info on the probabilities.
 
-USAGE: tests/test_learn.py contains numerical examples.
+Usage
+-----
+``tests/test_learn.py`` contains numerical examples.
 
-REFERENCES
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+References
+----------
+
 - David J.C. MacKay (2008), Information theory, Inference, and Learning
     Algorithms, 7th printing from Cambridge U. Press.
 - Softmax, https://compute.quora.com/What-is-softmax?share=1
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-13  Spin-off doctests to tests/test_learn.py.
-2018-06-12  learn.py, fecon236 fork. Fix imports, pass flake8, pass doctest.
-2017-06-09  ys_mlearn.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-06-13  Spin-off doctests to ``tests/test_learn.py``.
+* 2018-06-12  ``learn.py``, ``fecon236`` fork. Fix imports, pass flake8, pass
+  doctest.
+* 2017-06-09  ``ys_mlearn.py``, fecon235 v5.18.0312, https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -28,15 +39,44 @@ from fecon236.util import system
 
 
 def softmax(it, temp=55, n=4):
-    '''Softmax probabilities for iterable where temp sets temperature tau.
-       Temperature tau is set as a temp percent of ensemble mean so that
-       the scaling of tau works well across many different scenarios.
-       Experiment with temp around 40 to 70; higher temp (100+)
-       will make it-scores more equi-probable, whereas probabilities
-       can be sharpened by decreasing temp towards 1.
-       Setting temp to 0 results in generic softmax without temperature.
-       Results are rounded to n decimal places.
-    '''
+    """Softmax probabilities for iterable where temp sets temperature tau.
+
+    Temperature tau is set as a ``temp`` percent of ensemble mean so that
+    the scaling of tau works well across many different scenarios.
+    Experiment with ``temp`` around 40 to 70; higher ``temp`` (100+)
+    will make it-scores more equi-probable, whereas probabilities
+    can be sharpened by decreasing ``temp`` towards 1.
+    Setting ``temp`` to ``0`` results in generic softmax without temperature.
+    Results are rounded to ``n`` decimal places.
+
+    Notes
+    -----
+    ``softmax_sort`` is obviously slower to compute than ``softmax``.
+    They serve different purposes, for example,
+    ``softmax()[-1][i]`` can track a particular i-th class of it, whereas
+    ``softmax_sort()[:3]`` will give information on the top 3 classes.
+
+    The TEMPERATURE is a proxy for the degree of uncertainty
+    in the relative estimation of it-scores, but can also serve
+    to diffuse errors, i.e. a diversification technique with
+    mathematical reasoning rooted in statistical mechanics,
+    information theory, and maximum likelihood statistics.
+    To test temperature variations, ``softmax`` will be much faster.
+
+    Usage
+    -----
+
+    .. code-block:: python
+
+        softmax_sort([-16, -8, 0, 4, 8, 16], temp=50, drop=0.05, renorm=False)
+        # [(0.5733, 5, 16.0), (0.2019, 4, 8.0), (0.1198, 3, 4.0), (0.0711, 2,
+        #  0.0)]
+
+        softmax_sort([-16, -8, 0, 4, 8, 16], temp=50, drop=0.05, renorm=True)
+        # [(0.5934, 5, 16.0), (0.209, 4, 8.0), (0.124, 3, 4.0), (0.0736, 2,
+        #  0.0)]
+
+    """
     #  Convert iterable to numpy array, then find index of its maximum value:
     arr = tool.toar(it)
     idmax = np.argmax(arr)
@@ -71,31 +111,16 @@ def softmax(it, temp=55, n=4):
     hardprob = softmax_approx[idmax]
     return [idmax, hardmax, hardprob, temp, softmax_approx]
 
-    #      __________ SOFTMAX USAGE NOTES
-    #      softmax_sort() is obviously slower to compute than softmax().
-    #      They serve different purposes, for example,
-    #      softmax()[-1][i] can track a particular i-th class of it, whereas
-    #      softmax_sort()[:3] will give information on the top 3 classes.
-    #
-    #      The TEMPERATURE is a proxy for the degree of uncertainty
-    #      in the relative estimation of it-scores, but can also serve
-    #      to diffuse errors, i.e. a diversification technique with
-    #      mathematical reasoning rooted in statistical mechanics,
-    #      information theory, and maximum likelihood statistics.
-    #      To test temperature variations, softmax() will be much faster.
 
-#  >>> softmax_sort([-16, -8, 0, 4, 8, 16], temp=50, drop=0.05, renorm=False)
-#  [(0.5733, 5, 16.0), (0.2019, 4, 8.0), (0.1198, 3, 4.0), (0.0711, 2, 0.0)]
-#
-#  >>> softmax_sort([-16, -8, 0, 4, 8, 16], temp=50, drop=0.05, renorm=True)
-#  [(0.5934, 5, 16.0), (0.209, 4, 8.0), (0.124, 3, 4.0), (0.0736, 2, 0.0)]
 
 
 def softmax_sort(it, temp=55, n=4, drop=0.00, renorm=False):
-    '''Softmax results sorted, include index; option to drop and renormalize.
-       Probabilities less than drop are ignored.
-       Setting renorm=True will make probabilities sum to 1.
-    '''
+    """Softmax results sorted, include index; option to drop and renormalize.
+
+    Probabilities less than drop are ignored.
+
+    Setting ``renorm=True`` will make probabilities sum to 1.
+    """
     arr = tool.toar(it)
     softmax_approx = softmax(arr, temp, n)[-1]
     #  Tuples are formatted as (probability, index, it-value)

--- a/fecon236/oc/optimize.py
+++ b/fecon236/oc/optimize.py
@@ -28,11 +28,10 @@ Suitability: if data is NOISY:
     minimum, or how fast it will if it does.
 
 Suitability: WITH knowledge of the gradient: quasi-Newton methods:
-      BFGS   (scipy.optimize.fmin_bfgs()), or
-    L-BFGS-B (scipy.optimize.fmin_l_bfgs_b())
-        where the former has larger computational overhead.
-        Knowledge here means analytical representation.
-        BFGS abbreviates Broyden-Fletcher-Goldfarb-Shanno.
+    BFGS   (scipy.optimize.fmin_bfgs()), or
+    L-BFGS-B (scipy.optimize.fmin_l_bfgs_b()) where the former has larger
+    computational overhead. Knowledge here means analytical representation.
+    BFGS abbreviates Broyden-Fletcher-Goldfarb-Shanno.
 
 Suitability: WITHOUT knowledge of the gradient:
     L-BFGS-B (scipy.optimize.fmin_l_bfgs_b())

--- a/fecon236/oc/optimize.py
+++ b/fecon236/oc/optimize.py
@@ -1,15 +1,11 @@
 #  Python Module for import                           Date : 2018-05-29
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  optimize.py :: Convex optimization given noisy data.
+"""Convex optimization given noisy data.
 
-We smooth some of the rough edges among the "scipy.optimize" algorithms.  Our
-"optimize" algorithm first begins by a coarse grid search, then unconstrained
+We smooth some of the rough edges among the ``scipy.optimize`` algorithms.  Our
+``optimize`` algorithm first begins by a coarse grid search, then unconstrained
 Nelder-Mead simplex method, and finally the refined L-BFGS-B method which
 approximates a low-rank Hessian so that we can work in high (>250) dimensions.
-
-USAGE: please see tests/test_optimize.py which also serves as a TUTORIAL for
-optimization of loss functions, given data and model.
 
 Our selected methods feature the following and their unification:
 
@@ -45,19 +41,33 @@ Suitability: WITHOUT knowledge of the gradient:
         if you have a specific strategy.
 
 General strategy:
-    For scipy.optimize.minimize():
+    For ``scipy.optimize.minimize``:
     http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html
-    a singe method must be selected.  However, our optimize() is a sequence of
-    methods which starts from brute to refined, in above order.
+    a singe method must be selected.  However, our ``optimize`` is a sequence
+    of methods which starts from brute to refined, in above order.
 
-REFERENCES:
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+Usage
+-----
+Please see ``tests/test_optimize.py`` which also serves as a TUTORIAL
+for optimization of loss functions, given data and model.
+
+References
+----------
+
 - Mathematical optimization using scipy
   http://www.scipy-lectures.org/advanced/mathematical_optimization
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-05-29  optimize.py, fecon236 fork. Pass flake8, fix imports.
-2016-04-08  ys_optimize.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-05-29  ``optimize.py``, ``fecon236`` fork. Pass flake8, fix imports.
+* 2016-04-08  ``ys_optimize.py``, fecon235 v5.18.0312, https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -80,13 +90,24 @@ DISPLAY = 0
 
 
 def minBrute(fun, boundpairs, funarg=(), grids=20):
-    '''Minimization by brute force grid search.
-           fun is our function to minimize, given parameters for optimization.
-           boundpairs is a list of (min, max) pairs for fun parameters.
-           funarg is a tuple of supplemental arguments for fun.
-           grids are number of steps are taken in each direction.
-    '''
-    #  http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.brute.html
+    """Minimization by brute force grid search.
+
+    Parameters
+    ----------
+    fun: function
+        Function to minimize, given parameters for optimization
+    boundpairs: list
+        List of (min, max) pairs for fun parameters
+    funarg: tuple
+        Supplemental arguments for fun
+    grids: int
+        Number of steps taken in each direction
+
+    References
+    ----------
+    http://docs.scipy.org/doc/scipy/reference/generated/
+    scipy.optimize.brute.html
+    """
     boundpairs = tuple(boundpairs)
     #  boundpairs actually must be a tuple consisting of (min,max) tuples.
     if DISPLAY:
@@ -103,14 +124,26 @@ def minBrute(fun, boundpairs, funarg=(), grids=20):
 
 
 def minNelder(fun, initial, funarg=()):
-    '''Nelder-Mead simplex algorithm.
-       fun is our function to minimize, given parameters for optimization.
-       initial parameter guesses must be an ndarray, i.e. np.array([...])
-       funarg is a tuple of supplemental arguments for fun.
-    '''
-    #  http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin.html
-    #  Nelder, J.A. and Mead, R. (1965), "A simplex method for function
-    #      minimization", The Computer Journal, 7, pp. 308-313
+    """Nelder-Mead simplex algorithm.
+
+    Parameters
+    ----------
+    fun: function
+        Function to minimize, given parameters for optimization
+    initial: numpy.ndarray
+        Initial parameter guesses
+    funarg: tuple
+        Supplemental arguments for fun
+
+    References
+    ----------
+
+    * http://docs.scipy.org/doc/scipy/reference/generated/
+      scipy.optimize.fmin.html
+    * Nelder, J.A. and Mead, R. (1965), "A simplex method for function
+      minimization", The Computer Journal, 7, pp. 308-313
+
+    """
     if DISPLAY:
         print(" ::  Display for minNelder() ... ")
     result = sop.fmin(func=fun, args=funarg, x0=initial, disp=DISPLAY)
@@ -119,20 +152,33 @@ def minNelder(fun, initial, funarg=()):
 
 
 def minBroyden(fun, initial, funarg=(), boundpairs=None):
-    '''Broyden-Fletcher-Goldfarb-Shanno L-BFGS-B algorithm with box boundaries.
-       At each step an approximate low-rank Hessian is refined,
-       so this should work in high (>250) dimensions.
-       fun is our function to minimize, given parameters for optimization.
-       initial parameter guesses must be an ndarray, i.e. np.array([...])
-       funarg is a tuple of supplemental arguments for fun.
-       boundpairs is an OPTIONAL list of (min, max) pairs for fun parameters,
-       where None can be used for either min or max to indicate no bound.
-    '''
-    #  http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.fmin_l_bfgs_b.html
-    #  Ref: C. Zhu, R. H. Byrd, J. Nocedal. L-BFGS-B: Algorithm 778: L-BFGS-B,
-    #  FORTRAN routines for large scale bound constrained optimization (1997),
-    #  ACM Transactions on Mathematical Software, 23, 4, pp. 550-560.
-    #      scipy function is actually a Python wrapper around Fortran code.
+    """Broyden-Fletcher-Goldfarb-Shanno L-BFGS-B algorithm with box boundaries.
+
+    At each step an approximate low-rank Hessian is refined,
+    so this should work in high (>250) dimensions.
+
+    Parameters
+    ----------
+    fun: function
+        Function to minimize, given parameters for optimization
+    initial: numpy.ndarray
+        Initial parameter guesses
+    funarg: tuple
+        Supplemental arguments for fun
+    boundpairs: list, optional
+        Pairs for fun parameters, where None can be used for either min or max
+        to indicate no bound
+
+    References
+    ----------
+
+    * http://docs.scipy.org/doc/scipy/reference/generated/
+      scipy.optimize.fmin_l_bfgs_b.html
+    * FORTRAN routines for large scale bound constrained optimization (1997),
+      ACM Transactions on Mathematical Software, 23, 4, pp. 550-560.
+      ``scipy`` function is actually a Python wrapper around Fortran code.
+
+    """
     if DISPLAY:
         print(" ::  Display for minBroyden() ... ")
     result = sop.fmin_l_bfgs_b(func=fun, args=funarg, x0=initial,
@@ -153,20 +199,32 @@ def minBroyden(fun, initial, funarg=(), boundpairs=None):
 
 
 def optimize(fun, initialpairs, funarg=(), grids=20):
-    '''Optimize by grid search, Nelder-Mead simplex, and L-BFGS-B methods.
-       First a broad global search, followed by coarse non-gradient method,
-       then refined quasi-Newton method by approximate low-rank Hessian.
-           fun is our function to minimize, given parameters for optimization.
-           funarg is a tuple of supplemental arguments for fun.
-           initialpairs is a list of (min, max) pairs for fun parameters.
-           grids are number of steps are taken in each direction.
-       However, here we are intentionally NOT CONSTRAINED by initialpairs.
-    '''
-    #  The argument initialpairs can be just our preliminary wild guess.
-    #  minBrute will respect initialpairs as strict boundpairs using grids,
-    #  however, better and better initial point estimates are passed
-    #  along to other algorithms which will ignore any strict bounds
-    #  if the minimization can be improved.
+    """Optimize by grid search, Nelder-Mead simplex, and L-BFGS-B methods.
+
+    First a broad global search, followed by coarse non-gradient method,
+    then refined quasi-Newton method by approximate low-rank Hessian.
+
+    Parameters
+    ----------
+    fun: function
+        Function to minimize, given parameters for optimization
+    initialpairs: list
+        Initial (min, max) pairs for fun parameters
+    funarg: tuple
+        Supplemental arguments for fun
+    grids: int
+        Number of steps are taken in each direction. Defaults to 20
+
+    Notes
+    -----
+    The argument ``initialpairs`` can be just our preliminary wild guess.
+    minBrute will respect ``initialpairs`` as strict boundpairs using grids,
+    however, better and better initial point estimates are passed
+    along to other algorithms which will ignore any strict bounds
+    if the minimization can be improved.
+
+    However, here we are intentionally NOT CONSTRAINED by ``initialpairs``.
+    """
     brute = minBrute(fun=fun, funarg=funarg, boundpairs=initialpairs,
                      grids=grids)
     if DISPLAY:

--- a/fecon236/parse/sec.py
+++ b/fecon236/parse/sec.py
@@ -1,23 +1,28 @@
 #  Python Module for import                           Date : 2018-06-12
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  sec.py :: Parse SEC, U.S. Securities and Exchange Commission
+"""Parse SEC, U.S. Securities and Exchange Commission
 
-For BEST results via pandas: install lxml,
-            and as fallback:         bs4 and html5lib.
+For BEST results via pandas: install ``lxml``,and as fallback: ``bs4`` and
+``html5lib``.
 
-REFERENCES:
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+References
+----------
 
 - SEC form 13F, http://www.sec.gov/answers/form13f.htm
-
 - fecon235 notebook SEC-13F-parse.ipynb derives and debugs this module.
   For static view, see https://git.io/13F
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-05-29  sec.py, fecon236 fork. Fix imports, pass flake8.
-                Fix internal doctest: usd "nnn" expressed now as "nnn.0".
-2016-02-22  yi_secform.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-05-29  ``sec.py``, ``fecon236`` fork. Fix imports, pass flake8.
+  Fix internal doctest: usd "nnn" expressed now as "nnn.0".
+* 2016-02-22  ``yi_secform.py``, fecon235 v5.18.0312, https://git.io/fecon235
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -31,7 +36,7 @@ druck150814 = 'http://www.sec.gov/Archives/edgar/data/1536411/000153641115000006
 
 
 def parse13f(url=druck150814):
-    '''Parse SEC form 13F into a pandas dataframe.'''
+    """Parse SEC form 13F into a pandas dataframe."""
     #     url should be for so-called Information Table in html/xml format.
     url = url.replace('https://', 'http://')
     #                  https cannot be read by lxml, surprisingly!
@@ -60,17 +65,23 @@ def parse13f(url=druck150814):
 
 
 def pcent13f(url=druck150814, top=7654321):
-    '''Prune, then sort SEC 13F by percentage allocation, showing top N.
-    >>> pcent13f(top= 7)
-                          stock      cusip       usd putcall  pcent
-    27          SPDR Gold Trust  78463V907  323626.0     NaN  21.81
-    15             Facebook Inc  30303M102  160612.0     NaN  10.82
-    29         Wells Fargo & Co  949746101   94449.0     NaN   6.36
-    31  LyondellBasell Ind's NV  N53745100   74219.0     NaN   5.00
-    18           Halliburton Co  406216101   66629.0     NaN   4.49
-    16     Freeport-McMoRan Inc  35671D857   66045.0     NaN   4.45
-    8             Citigroup Inc  172967424   64907.0     NaN   4.37
-    '''
+    """Prune, then sort SEC 13F by percentage allocation, showing top N.
+
+    Usage
+    -----
+
+    ::
+
+        >>> pcent13f(top= 7)
+                              stock      cusip       usd putcall  pcent
+        27          SPDR Gold Trust  78463V907  323626.0     NaN  21.81
+        15             Facebook Inc  30303M102  160612.0     NaN  10.82
+        29         Wells Fargo & Co  949746101   94449.0     NaN   6.36
+        31  LyondellBasell Ind's NV  N53745100   74219.0     NaN   5.00
+        18           Halliburton Co  406216101   66629.0     NaN   4.49
+        16     Freeport-McMoRan Inc  35671D857   66045.0     NaN   4.45
+        8             Citigroup Inc  172967424   64907.0     NaN   4.37
+    """
     df = parse13f(url)
     #    Drop irrevelant COLUMNS:
     df.drop(df.columns[[1, 4, 5, 7, 8, 9, 10, 11]], axis=1, inplace=True)

--- a/fecon236/prob/sim.py
+++ b/fecon236/prob/sim.py
@@ -1,24 +1,28 @@
 #  Python Module for import                           Date : 2018-07-04
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  sim.py :: Simulation module for fecon236
+"""Simulation module for fecon236
 
 - Essential probabilistic functions for simulations.
-- Synthesis of prices from Gaussian mixture model GM(2), see gmix2prices().
-- Visualize simulated price paths, see simushow() and gmixshow().
+- Synthesis of prices from Gaussian mixture model GM(2), see ``gmix2prices``.
+- Visualize simulated price paths, see ``simushow`` and ``gmixshow``.
 - Let N be an integer for sample size or length of a series.
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-07-04  Add gmix2ret() and SPX constants for default arguments.
-                Add supplemental gmix2prices() and gmixshow().
-2018-07-01  Add norat2ret() and ret2prices().
-                Replace rates2prices by zerat2prices for clarity.
-                Rename simshow() to simushow() and use new function.
-2018-06-09  Add rates2prices() and summary simshow().
-2018-06-08  Spin-off 2014 bootstrap material to boots/bootstrap.py.
-2018-06-07  Rename to sim.py, fecon236 fork. Pass flake8, fix imports.
-2017-06-29  yi_simulation.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-07-04  Add ``gmix2ret`` and SPX constants for default arguments. Add
+  supplemental ``gmix2prices`` and ``gmixshow``.
+* 2018-07-01  Add ``norat2ret`` and ``ret2prices``. Replace ``rates2prices`` by
+  ``zerat2prices`` for clarity. Rename ``simshow`` to ``simushow`` and use new
+  function.
+* 2018-06-09  ``Add rates2prices`` and summary ``simshow``.
+* 2018-06-08  Spin-off 2014 bootstrap material to ``boots/bootstrap.py``.
+* 2018-06-07  Rename to ``sim.py``, ``fecon236`` fork. Pass flake8, fix
+  imports.
+* 2017-06-29  ``yi_simulation.py``, fecon235 v5.18.0312,
+  https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -41,14 +45,14 @@ SPXinprice = 46.20     # initial price
 
 
 def randou(upper=1.0):
-    '''Single random float, not integer, from Uniform[0.0, upper).'''
+    """Single random float, not integer, from ``Uniform[0.0, upper)``."""
     #  Closed lower bound of zero, and argument for open upper bound.
-    #  To generate arrays, please use np.random.random().
+    #  To generate arrays, please use ``np.random.random``.
     return np.random.uniform(low=0.0, high=upper, size=None)
 
 
 def maybe(p=0.50):
-    '''Uniformly random indicator function such that prob(I=1=True) = p.'''
+    """Uniformly random indicator function such that ``prob(I=1=True) = p``."""
     #  Nice to have for random "if" conditional branching.
     #  Fun note: Python's boolean True is actually mapped to int 1.
     if randou() <= p:
@@ -58,7 +62,7 @@ def maybe(p=0.50):
 
 
 def randog(sigma=1.0):
-    '''Single random float from Gaussian N(0.0, sigma^2).'''
+    """Single random float from Gaussian ``N(0.0, sigma^2)``."""
     #  Argument sigma is the standard deviation, NOT the variance!
     #  For non-zero mean, just add it to randog later.
     #  To generate arrays, please use simug().
@@ -66,10 +70,10 @@ def randog(sigma=1.0):
 
 
 def simug(sigma=SPXsigma/16., N=256):
-    '''Simulate array of shape (N,) from Gaussian Normal(0.0, sigma^2).
-       Argument sigma is the standard deviation, NOT the variance!
-       Note the use of raw sigma, which is not necessarily annualized.
-    '''
+    """Simulate array of shape ``(N,)`` from Gaussian Normal(0.0, sigma^2).
+       Argument ``sigma`` is the standard deviation, NOT the variance!
+       Note the use of raw ``sigma``, which is not necessarily annualized.
+    """
     #  Default sigma is stylized per daily SPX data, see https://git.io/gmix
     ratarr = sigma * np.random.randn(N)
     #  For non-zero mean, simply add it later: mu + simug(sigma)
@@ -77,9 +81,9 @@ def simug(sigma=SPXsigma/16., N=256):
 
 
 def simug_mix(sigma1=SPXsigma1/16., sigma2=SPXsigma2/16., q=SPXq, N=256):
-    '''Simulate array from zero-mean Gaussian mixture GM(2).
+    """Simulate array from zero-mean Gaussian mixture GM(2).
        Note the use of raw sigmas, which are not necessarily annualized.
-    '''
+    """
     #  Default values are stylized per daily SPX data, see https://git.io/gmix
     #  Mathematical details in fecon235/nb/gauss-mix-kurtosis.ipynb
     #     Pre-populate an array of shape (N,) with the FIRST Gaussian,
@@ -96,10 +100,15 @@ def simug_mix(sigma1=SPXsigma1/16., sigma2=SPXsigma2/16., q=SPXq, N=256):
 
 
 def norat2ret(normarr, mean, sigma, yearly=256):
-    '''Reform array of N(0, 1) normalized RATES into array of RETURNS.
-       Arguments mean and sigma should be in decimal form.
-       Argument yearly expresses frequency to be obtained.
-    '''
+    """Reform array of N(0, 1) normalized RATES into array of RETURNS.
+
+    Parameters
+    ----------
+    mean: float
+    sigma: float
+    yearly: int
+       Frequency to be obtained
+    """
     meanly = mean / yearly   # e.g. 256 trading days in a year.
     sigmaly = sigma / (yearly ** 0.5)
     retarr = (1 + meanly) + (sigmaly * normarr)
@@ -109,10 +118,14 @@ def norat2ret(normarr, mean, sigma, yearly=256):
 
 
 def ret2prices(retarr, inprice=1.0):
-    '''Transform array of returns into DataFrame of prices.'''
-    #  For cumulative product of array elements,
-    #  numpy's cumprod is very fast, and records the ongoing results.
-    #  http://docs.scipy.org/doc/numpy/reference/generated/numpy.cumprod.html
+    """Transform array of returns into DataFrame of prices.
+
+    Notes
+    -----
+    For cumulative product of array elements,
+    numpy's ``cumprod`` is very fast, and records the ongoing results.
+    http://docs.scipy.org/doc/numpy/reference/generated/numpy.cumprod.html
+    """
     prices = np.cumprod(retarr)  # prices here is in np.array form.
     #      Initial price implicitly starts at 1 where
     #      the history of prices is just the products of the returns.
@@ -123,7 +136,7 @@ def ret2prices(retarr, inprice=1.0):
 
 
 def zerat2prices(ratarr, mean=0, yearly=256, inprice=1.0):
-    '''Transform array of mean-0 rates into DataFrame of prices with mean.'''
+    """Transform array of mean-0 rates into DataFrame of prices with mean."""
     #  Default inprice means initial price implicitly starts at 1.
     meanly = mean / yearly   # e.g. 256 trading days in a year.
     retarr = (1 + meanly) + ratarr
@@ -132,9 +145,9 @@ def zerat2prices(ratarr, mean=0, yearly=256, inprice=1.0):
 
 def simushow(N=256, mean=0, yearly=256, repeat=1, func=simug_mix, visual=True,
              b=SPXb, inprice=100):
-    '''Statistical and optional visual SUMMARY: repeat simulations of func.
-       Function func shall use all its default arguments, except for N.
-    '''
+    """Statistical and optional visual SUMMARY: repeat simulations of ``func``.
+       Function ``func`` shall use all its default arguments, except for ``N``.
+    """
     for i in range(repeat):
         istr = str(i)
         ratarr = func(N=N)
@@ -150,10 +163,14 @@ def simushow(N=256, mean=0, yearly=256, repeat=1, func=simug_mix, visual=True,
 
 
 def gmix2ret(N=256, mean=SPXmean, sigma=SPXsigma, yearly=256):
-    '''Simulate array of GM(2) returns given arithmetic mean and plain sigma.
-       GAUSSIAN MIXTURE is synthesized through primitive sim functions.
-       Default values are stylized per daily SPX data, see https://git.io/gmix
-    '''
+    """Simulate array of GM(2) returns given arithmetic ``mean`` and plain
+    ``sigma``.
+
+    Notes
+    -----
+    GAUSSIAN MIXTURE is synthesized through primitive sim functions.
+    Default values are stylized per daily SPX data, see https://git.io/gmix
+    """
     sigmaly = SPXsigma / (yearly ** 0.5)
     sigmaly1 = SPXsigma1 / (yearly ** 0.5)
     sigmaly2 = SPXsigma2 / (yearly ** 0.5)
@@ -169,16 +186,19 @@ def gmix2ret(N=256, mean=SPXmean, sigma=SPXsigma, yearly=256):
 
 
 def gmix2prices(N=256, mean=SPXmean, sigma=SPXsigma, yearly=256, inprice=1.0):
-    '''Simulate N prices from GM(2) given arithmetic mean and plain sigma.
-       GAUSSIAN MIXTURE is synthesized through primitive sim functions.
-    '''
+    """Simulate N prices from GM(2) given arithmetic mean and plain sigma.
+
+    Notes
+    -----
+    GAUSSIAN MIXTURE is synthesized through primitive sim functions.
+    """
     retarr = gmix2ret(N, mean, sigma, yearly)
     return ret2prices(retarr, inprice)
 
 
 def gmixshow(N=256, mean=SPXmean, sigma=SPXsigma, yearly=256, repeat=1,
              visual=True, inprice=100, b=SPXb):
-    '''Statistical and optional visual SUMMARY: repeat simulations of GM(2).'''
+    """Statistical and optional visual SUMMARY: repeat simulations of GM(2)."""
     for i in range(repeat):
         istr = str(i)
         prices = gmix2prices(N, mean, sigma, yearly, inprice)

--- a/fecon236/prtf/boltzmann.py
+++ b/fecon236/prtf/boltzmann.py
@@ -1,14 +1,10 @@
 #  Python Module for import                           Date : 2018-06-20
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  boltzmann.py :: Boltzmann portfolio for fecon236
+"""Boltzmann portfolio for fecon236
 
 Alternative to Markowitz portfolio. Usage demonstrated in notebook, see
 fecon235/nb/prtf-boltzmann-1.ipynb for explicit details and derivation,
 or Part 1: https://git.io/boltz1 and Part 2: https://git.io/boltz2
-
-    The softmax() function is in fecon236/ml/learn.py since it applies
-    more widely in machine learning.
 
 One virtually has no control over how the assets perform and interact. Only
 the portfolio allocation over time is in our decision set. Let's recast the
@@ -32,6 +28,7 @@ Those weights depend on the covariance structure of the agents' performance
 which is unfortunately not stable over time. There may be some information
 which can be exploited to tilt our bets favorably.
 
+::
 
     prices ---> cov ---> globalw
       |                    |
@@ -56,7 +53,7 @@ To summarize the information set so far, we cast the agents in a game, each
 with some score. When the game consists of multiple rounds, we can use tools
 from reinforcement learning to help us make the best sequential decisions.
 
-The softmax function is fed the scores to compute the probability of a
+The ``softmax`` function is fed the scores to compute the probability of a
 particular agent being the expert. This function takes temperature as a
 diffusion parameter, that is, an optimal way to diversify our bets across
 possible experts. The theory here is due to Ludwig Boltzmann and his work
@@ -67,15 +64,24 @@ estimating the various measures.
 Finally, those probabilities are combined with our renormalized weights to
 arrive at "pweights," our portfolio weights.
 
+Notes
+-----
+* The ``softmax`` function is in ``fecon236/ml/learn.py`` since it applies
+  more widely in machine learning.
+* For LATEST version, see https://git.io/fecon236
 
-REFERENCES
+References
+----------
 
 - John H. Cochrane, 2005, Asset Pricing, Princeton U. Press.
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-20  boltzmann.py, fecon236 fork. Fix imports, pass flake8.
-2017-07-08  ys_prtf_boltzmann.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-06-20  ``boltzmann.py``, ``fecon236`` fork. Fix imports, pass flake8.
+* 2017-07-08  ``ys_prtf_boltzmann.py``, fecon235 v5.18.0312,
+  https://git.io/fecon235
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -89,7 +95,7 @@ from fecon236.ml import learn
 
 
 def weighcov(cov):
-    '''WEIGHT array (N,1) for Global Min Var Portfolio, given cov.'''
+    """WEIGHT array (N,1) for Global Min Var Portfolio, given cov."""
     #  Derived in Cochrane (2005), chp. 5, p.83.
     Viv = matrix.invert_pseudo(cov)
     #                  ^in case covariance matrix is ill-conditioned.
@@ -100,13 +106,13 @@ def weighcov(cov):
 
 
 def weighcovdata(dataframe):
-    '''WEIGHT array (N,1) for Global Min Var Portfolio, given data.'''
+    """WEIGHT array (N,1) for Global Min Var Portfolio, given data."""
     V = matrix.covdiflog(dataframe)
     return weighcov(V)
 
 
 def trimit(it, floor, level):
-    '''For an iterable, accept values > floor, else set to level.'''
+    """For an iterable, accept values > floor, else set to level."""
     try:
         #  ... in case "it" array elements are integers,
         #  else we cannot assign floats later when enumerating:
@@ -121,10 +127,11 @@ def trimit(it, floor, level):
 
 
 def renormalize(it):
-    '''Let elements of an iterable proportionally abs(sum) to 1.
-       Renormalization of portfolio weights is treated differently
-       than probabilities which cannot be negative.
-    '''
+    """Let elements of an iterable proportionally abs(sum) to 1.
+
+    Renormalization of portfolio weights is treated differently
+    than probabilities which cannot be negative.
+    """
     #  Remember that a list is an iterable, too.
     arr = np.array([float(x) for x in it])
     sumit = float(np.sum(arr))
@@ -143,19 +150,19 @@ def renormalize(it):
 
 
 def rentrim(weights, floor, level):
-    '''Accept weight > floor, else set to level, then renormalize.'''
+    """Accept weight > floor, else set to level, then renormalize."""
     trimmed = trimit(weights, floor, level)
     return renormalize(trimmed)
 
 
 def gemratarr(dataframe, yearly=256):
-    '''Extract geometric mean rate of each column into an array.'''
+    """Extract geometric mean rate of each column into an array."""
     gems = group.groupgemrat(dataframe, yearly, order=False, n=8)
     return np.array([item[0] for item in gems]).reshape(len(gems), 1)
 
 
 def weighsoft(weights, rates, temp, floor, level):
-    '''Given weights, compute pweights as array by softmax transform.'''
+    """Given weights, compute pweights as array by softmax transform."""
     scores = weights * rates
     problist = learn.softmax(scores, temp)[-1]
     probs = np.array(problist).reshape(len(problist), 1)
@@ -166,7 +173,7 @@ def weighsoft(weights, rates, temp, floor, level):
 
 
 def boltzweigh(dataframe, yearly=256, temp=55, floor=0.01, level=0):
-    '''Given data, compute pweights as array by softmax transform.'''
+    """Given data, compute pweights as array by softmax transform."""
     rates = gemratarr(dataframe, yearly)
     globalw = weighcovdata(dataframe)
     weights = rentrim(globalw, floor, level)
@@ -175,18 +182,23 @@ def boltzweigh(dataframe, yearly=256, temp=55, floor=0.01, level=0):
 
 
 def boltzportfolio(dataframe, yearly=256, temp=55, floor=0.01, level=0, n=4):
-    '''MAIN: SUMMARY of Boltzmann portfolio, rounded to n-decimal places.
-       Return list where values are Python floats, not array type, e.g.
-           [2.7833,
-            [[0.6423, 2.05, 'America'],
-             [0.0, -11.17, 'Emerging'],
-             [0.0, -10.47, 'Europe'],
-             [0.3577, 4.1, 'Gold'],
-             [0.0, -4.99, 'Japan']]]
-       The portfolio's geometric mean rate is included first.
-       Each sub-sublist will consist of weight, rate, and key.
-       The order of keys from the dataframe is preserved.
-    '''
+    """SUMMARY of Boltzmann portfolio, rounded to n-decimal places.
+
+    Return list where values are Python floats, not array type, e.g.
+
+    .. code-block:: python
+
+        [2.7833,
+        [[0.6423, 2.05, 'America'],
+         [0.0, -11.17, 'Emerging'],
+         [0.0, -10.47, 'Europe'],
+         [0.3577, 4.1, 'Gold'],
+         [0.0, -4.99, 'Japan']]]
+
+    The portfolio's geometric mean rate is included first.
+    Each sub-sublist will consist of weight, rate, and key.
+    The order of keys from the dataframe is preserved.
+    """
     rates = gemratarr(dataframe, yearly)
     globalw = weighcovdata(dataframe)
     weights = rentrim(globalw, floor, level)

--- a/fecon236/prtf/boltzmann.py
+++ b/fecon236/prtf/boltzmann.py
@@ -189,11 +189,11 @@ def boltzportfolio(dataframe, yearly=256, temp=55, floor=0.01, level=0, n=4):
     .. code-block:: python
 
         [2.7833,
-        [[0.6423, 2.05, 'America'],
-         [0.0, -11.17, 'Emerging'],
-         [0.0, -10.47, 'Europe'],
-         [0.3577, 4.1, 'Gold'],
-         [0.0, -4.99, 'Japan']]]
+         [[0.6423, 2.05, 'America'],
+          [0.0, -11.17, 'Emerging'],
+          [0.0, -10.47, 'Europe'],
+          [0.3577, 4.1, 'Gold'],
+          [0.0, -4.99, 'Japan']]]
 
     The portfolio's geometric mean rate is included first.
     Each sub-sublist will consist of weight, rate, and key.

--- a/fecon236/rates/credit.py
+++ b/fecon236/rates/credit.py
@@ -1,14 +1,21 @@
 #  Python Module for import                           Date : 2018-11-29
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  credit.py :: Credit risk module for fecon236
+"""Credit risk module for fecon236
 
-- For detailed derivation of Unified Credit Profile, creditprof(),
+- For detailed derivation of Unified Credit Profile, ``creditprof``,
     see fecon235 notebook, https://git.io/creditprof
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-11-29  Add creditprof().
-'''
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+
+Change Log
+----------
+
+* 2018-11-29  Add ``creditprof``.
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -19,10 +26,13 @@ from fecon236.host.fred import d4bond10, daily
 
 
 def creditprof():
-    '''Credit profile derived from mortgage and corporate credit spreads.'''
-    #  Derivation in fecon235/nb/fred-credit-spreads.ipynb
-    #  See https://git.io/creditprof
-    #  First, note the oldest start date common among all series herein:
+    """Credit profile derived from mortgage and corporate credit spreads.
+
+    Derivation in fecon235/nb/fred-credit-spreads.ipynb
+    See https://git.io/creditprof
+    First, note the oldest start date common among all series herein:
+    """
+
     start = '1991-08-30'
     #  ----- MORTGAGE CREDIT SPREAD
     #  Freddie Mac 15-Year Fixed Rate Mortgage v. Treasury 10-year bond.

--- a/fecon236/rates/fedfunds.py
+++ b/fecon236/rates/fedfunds.py
@@ -1,15 +1,21 @@
 #  Python Module for import                           Date : 2018-06-17
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  fedfunds.py :: Fed Funds rate module for fecon236
+"""Fed Funds rate module for fecon236
 
-- For derivation of forefunds() which forecasts the Fed Funds rate,
+- For derivation of ``forefunds`` which forecasts the Fed Funds rate,
     see https://git.io/fedfunds
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-17  Spin-off forefunds() from top.py.
-'''
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
 
+
+Change Log
+----------
+
+* 2018-06-17  Spin-off ``forefunds`` from ``top.py``.
+
+"""
 from __future__ import absolute_import, print_function, division
 
 from fecon236.util import system
@@ -19,9 +25,12 @@ from fecon236.tsa.holtwinters import ema
 
 
 def forefunds(nearby='16m', distant='17m'):
-    '''Forecast distant Fed Funds rate using Eurodollar futures.'''
-    #  Derivation in fecon235/nb/qdl-libor-fed-funds.ipynb
-    #  See https://git.io/fedfunds
+    """Forecast distant Fed Funds rate using Eurodollar futures.
+
+    Derivation in fecon235/nb/qdl-libor-fed-funds.ipynb
+
+    See https://git.io/fedfunds
+    """
     ffer = get('DFF')
     #      ^Retrieve Fed Funds effective rate, daily since 1954.
     ffer_ema = ema(ffer['1981':], 0.0645)

--- a/fecon236/tool.py
+++ b/fecon236/tool.py
@@ -1,30 +1,38 @@
 #  Python Module for import                           Date : 2018-11-29
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  tool.py :: Fundamental tools for data analysis.
+"""Fundamental tools for data analysis.
 
-REFERENCES:
+
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+References
+----------
 
 - Data structures, http://pandas.pydata.org/pandas-docs/dev/dsintro.html
-
 - pandas, http://pandas.pydata.org/pandas-docs/stable/computation.html
 
-Note that np.float() is just an alias to Python's float type,
+Note that ``np.float`` is just an alias to Python's ``float`` type,
 which is only exposed for backwards compatibility with a very early
-version of numpy that inappropriately exposed np.float64 as np.float,
-causing problems upon: from numpy import *
-   - np.float() is not a numpy scalar type like np.float64()
-   - Plain float() is fine for our numerical work here.
+version of numpy that inappropriately exposed ``np.float64`` as ``np.float``,
+causing problems upon: ``from numpy import *``
+
+- ``np.float`` is not a ``numpy`` scalar type like ``np.float64``
+- Plain ``float`` is fine for our numerical work here.
 
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-11-29  Add median(), mad(), and madmen() for robust rescaling.
-2018-07-08  Modify kurtfun() with population argument.
-2018-07-07  Add std() with population argument for ddof.
-2018-05-11  Rename to tool.py, fix imports.
-2018-05-09  tools.py, fecon236 fork. Pass flake8.
-2017-06-20  yi_1tools.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-11-29  Add ``median``, ``mad``, and ``madmen`` for robust rescaling.
+* 2018-07-08  Modify ``kurtfun`` with population argument.
+* 2018-07-07  Add ``std`` with population argument for ddof.
+* 2018-05-11  Rename to ``tool.py``, fix imports.
+* 2018-05-09  ``tools.py``, ``fecon236`` fork. Pass flake8.
+* 2017-06-20  yi_1tools.py, fecon235 v5.18.0312, https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -35,7 +43,7 @@ from fecon236.util import system
 
 
 def nona(df):
-    '''Eliminate any row in a dataframe containing NA, NaN nulls.'''
+    """Eliminate any row in a dataframe containing NA, NaN nulls."""
     return df.dropna()
     #  When calculating among dataframes, sometimes null entries
     #  are produced where the indexes are overlapping.
@@ -43,17 +51,17 @@ def nona(df):
 
 
 def head(dfx, n=7):
-    '''Quick look at the INITIAL data point(s).'''
+    """Quick look at the INITIAL data point(s)."""
     return dfx.head(n)
 
 
 def tail(dfx, n=7):
-    '''Quick look at the LATEST data point(s).'''
+    """Quick look at the LATEST data point(s)."""
     return dfx.tail(n)
 
 
 def tailvalue(df, pos=0, row=1):
-    '''Seek (last) row of dataframe, then the element at position pos.'''
+    """Seek (last) row of dataframe, then the element at position pos."""
     #  For pos, the index is not considered.
     return df.tail(row).values.tolist()[0][pos]
     #      values to array to list within list, then the element.
@@ -61,7 +69,7 @@ def tailvalue(df, pos=0, row=1):
 
 
 def div(numerator, denominator, floor=False):
-    '''Division via numpy for pandas, Python 2 and 3 compatibility.
+    """Division via numpy for pandas, Python 2 and 3 compatibility.
         Returns a scalar if both inputs are scalar, ndarray otherwise.
         We shall AVOID the ambiguous python2-like: np.divide()
     >>> x = np.array([0, 1, 2, 3, 4])
@@ -75,7 +83,7 @@ def div(numerator, denominator, floor=False):
     0.5
     >>> div(2, 0)  # Dividing by zero returns infinity, not error:
     inf
-    '''
+    """
     if floor:
         #      Like python3 "//":
         return np.floor_divide(numerator, denominator)
@@ -85,7 +93,7 @@ def div(numerator, denominator, floor=False):
 
 
 def roundit(it, n=4, echo=True):
-    '''Echo or return list from iterable where floats are rounded n places.'''
+    """Echo or return list from iterable where floats are rounded n places."""
     lst = [round(x, n) if isinstance(x, float) else x for x in it]
     #                                           ^e.g. exempt int and strings.
     if echo:
@@ -95,18 +103,18 @@ def roundit(it, n=4, echo=True):
 
 
 def dif(dfx, freq=1):
-    '''Lagged difference for pandas series.'''
+    """Lagged difference for pandas series."""
     #  Thus freq=1 gives so-called "first difference."
     return dfx.diff(periods=freq)
 
 
 def pcent(dfx, freq=1):
-    '''PERCENTAGE CHANGE method for pandas.'''
+    """PERCENTAGE CHANGE method for pandas."""
     return dfx.pct_change(periods=freq) * 100
 
 
 def retrace(minimum, maximum, percent=50):
-    '''Compute retracement between minimum and maximum.
+    """Compute retracement between minimum and maximum.
         Noteworthy Fibonacci retracements: 23.6%, 38.2%, 61.8%
         Set percent as negative for retracement down from maximum,
         whereas positive percent implies retrace up from the minimum.
@@ -114,7 +122,7 @@ def retrace(minimum, maximum, percent=50):
     90.0
     >>> retrace(10, 110, 20)
     30.0
-    '''
+    """
     if isinstance(minimum, pd.DataFrame):
         system.die("DataFrame argument UNACCEPTABLE. Try retracedf()")
     span = maximum - minimum
@@ -127,7 +135,7 @@ def retrace(minimum, maximum, percent=50):
 
 
 def retracedf(dfx, percent=50):
-    '''Compute retracement between minimum and maximum of dataframe.'''
+    """Compute retracement between minimum and maximum of dataframe."""
     #  Set percent as negative for retracement down from maximum,
     #  whereas positive percent implies retrace up from the minimum.
     minimum = dfx.min().iloc[0]
@@ -137,7 +145,7 @@ def retracedf(dfx, percent=50):
 
 
 def georet(dfx, yearly=256):
-    '''Compute geometric mean return in a summary list.'''
+    """Compute geometric mean return in a summary list."""
     #  yearly refers to frequency, e.g. 256 for daily trading days,
     #                                    12 for monthly,
     #                                     4 for quarterly.
@@ -167,7 +175,7 @@ def georet(dfx, yearly=256):
 
 
 def zeroprice(rate, duration=9, yearly=2, face=100):
-    '''Compute price of zero-coupon bond given its duration.'''
+    """Compute price of zero-coupon bond given its duration."""
     #  Assume rate is in percentage form, e.g. 2.5% (not 0.025).
     #         rate could be a dataframe column.
     #  2014-08-28  duration of 10-y Treasury is 9.1 approx.
@@ -178,11 +186,11 @@ def zeroprice(rate, duration=9, yearly=2, face=100):
 
 
 def std(data, population=False):
-    '''Compute standard deviation with delta degrees of freedom, ddof.
+    """Compute standard deviation with delta degrees of freedom, ddof.
        Default population=False is compatible with pandas and MATLAB
        since both defaults to SAMPLE standard deviation
        (using so-called Bessel's correction of N-1).
-    '''
+    """
     #  Ref: https://stackoverflow.com/questions/27600207
     #  ddof must be integer-valued (not boolean):
     if population:
@@ -200,23 +208,23 @@ def std(data, population=False):
 
 
 def normalize(dfy):
-    '''Center around mean zero and standardize deviation.'''
+    """Center around mean zero and standardize deviation."""
     centered = dfy - dfy.mean().tolist()[0]
     return centered / float(dfy.std().tolist()[0])
 
 
 def median(dfy, col=0):
-    '''Compute the median (by default, of the first dataframe column).'''
+    """Compute the median (by default, of the first dataframe column)."""
     return dfy.median().tolist()[col]
 
 
 def mad(dfy):
-    '''Median Absolute Deviation is a robust measure of dispersion:
+    """Median Absolute Deviation is a robust measure of dispersion:
     MAD = 0.67449*sigma if distribution is Gaussian, i.e.
     3*MAD is about 2*sigma; however, MAD is resilient to outliers,
     thus very useful in non-Gaussian situations.
     See https://en.wikipedia.org/wiki/Median_absolute_deviation
-    '''
+    """
     dev = dfy - median(dfy)  # Deviations from median.
     #  MAD is defined as the median (not the mean)
     #  of absolute deviations from the data's median:
@@ -224,17 +232,17 @@ def mad(dfy):
 
 
 def madmen(dfy):
-    '''Rescale data as unitless MAD multiples, after shifting median to zero.
+    """Rescale data as unitless MAD multiples, after shifting median to zero.
     The main character in the "Mad Men" series pretending to be Donald Draper
     is akin to our data pretending to be Gaussian, which we robustly unmask.
     [Cf. alternative normalize() where large deviations are squared.]
-    '''
+    """
     dev = dfy - median(dfy)  # Deviations from median.
     return dev / mad(dfy)
 
 
 def correlate(dfy, dfx, type='pearson'):
-    '''CORRELATION FUNCTION between series using pandas method.'''
+    """CORRELATION FUNCTION between series using pandas method."""
     #  N.B. -  must specify column(s) within dataframe(s) !
     #              Types of correlations:
     #  'pearson'   Standard correlation coefficient
@@ -244,7 +252,7 @@ def correlate(dfy, dfx, type='pearson'):
 
 
 def cormatrix(dataframe, type='pearson'):
-    '''PAIRWISE CORRELATIONS within a dataframe using pandas method.'''
+    """PAIRWISE CORRELATIONS within a dataframe using pandas method."""
     #              Types of correlations:
     #  'pearson'   Standard correlation coefficient
     #  'kendall' 	Kendall Tau correlation coefficient
@@ -253,7 +261,7 @@ def cormatrix(dataframe, type='pearson'):
 
 
 def regressformula(df, formula):
-    '''Helper function for statsmodel linear regression using formula.'''
+    """Helper function for statsmodel linear regression using formula."""
     #
     #  FORMULA is a string like "Y ~ 0 + X + Z"
     #          where column names of the df dataframe are used.
@@ -270,7 +278,7 @@ def regressformula(df, formula):
 
 
 def regressTIME(dfy, col='Y'):
-    '''Regression on time since that index cannot be independent variable.'''
+    """Regression on time since that index cannot be independent variable."""
     #  Assuming time series is evenly-spaced...
     df = dfy.dropna()
     #        ^insures proper alignment with timer:
@@ -291,7 +299,7 @@ def regressTIME(dfy, col='Y'):
 
 
 def regresstime(dfy, col='Y'):
-    '''Regression on time since that index cannot be independent variable.'''
+    """Regression on time since that index cannot be independent variable."""
     #  Return just the fitted dataframe with original time intact.
     results = regressTIME(dfy, col)
     c, slope = results[1]
@@ -300,7 +308,7 @@ def regresstime(dfy, col='Y'):
 
 
 def regresstimeforecast(dfy, h=24, col='Y'):
-    '''Forecast h-periods ahead based on linear regression on time.'''
+    """Forecast h-periods ahead based on linear regression on time."""
     c, slope = regressTIME(dfy, col)[1]
     forecast = [c + (slope * i) for i in range(h+1)]
     #  h=0 corresponds to the latest fitted point by design,
@@ -316,26 +324,26 @@ foretrend = regresstimeforecast
 
 
 def detrend(dfy, col='Y'):
-    '''Detread using linear regression on time.'''
+    """Detread using linear regression on time."""
     trend = regresstime(dfy, col)
     return dfy - trend
 
 
 def detrendpc(dfy, col='Y'):
-    '''Detread using linear regression on time; percent deviation.'''
+    """Detread using linear regression on time; percent deviation."""
     trend = regresstime(dfy, col)
     #  return ((dfy - trend) * 100.00) / trend  #-X 2015-12-28
     return div((dfy - trend)*100, trend)
 
 
 def detrendnorm(dfy, col='Y'):
-    '''Detread using linear regression on time, then normalize.'''
+    """Detread using linear regression on time, then normalize."""
     trend = regresstime(dfy, col)
     return normalize(dfy - trend)
 
 
 def regress(dfy, dfx, intercept=True):
-    '''Perform LINEAR REGRESSION, a.k.a. Ordinary Least Squares.'''
+    """Perform LINEAR REGRESSION, a.k.a. Ordinary Least Squares."""
     #  2016-04-28  DEPRECATED ols from pandas.stats.api as of pandas 0.18,
     #                 so use regressformula() instead.
     #                 Add intercept option as boolean.    <= New feature!
@@ -356,10 +364,10 @@ def regress(dfy, dfx, intercept=True):
 
 
 def kurtfun(data, raw=False, population=False):
-    '''Compute kurtosis of an array or a single column DataFrame.
+    """Compute kurtosis of an array or a single column DataFrame.
        Default uses PEARSON fourth central moment, where kurtosis is 3
        if data is Gaussian. Fischer "excess kurtosis":= k_Pearson-3.
-    '''
+    """
     arr = toar(data)
     mu = np.mean(arr)
     sigma = std(arr, population=population)
@@ -379,7 +387,7 @@ def kurtfun(data, raw=False, population=False):
 
 
 def stat2(dfy, dfx, intercept=True):
-    '''Quick STATISTICAL SUMMARY and regression on two variables'''
+    """Quick STATISTICAL SUMMARY and regression on two variables"""
     print(" ::  FIRST variable:")
     now = dfy.describe()
     print(now)
@@ -397,7 +405,7 @@ def stat2(dfy, dfx, intercept=True):
 
 
 def stat(data, pctiles=[0.25, 0.50, 0.75]):
-    '''QUICK summary statistics on given dataframe.'''
+    """QUICK summary statistics on given dataframe."""
     dataframe = todf(data)
     print(dataframe.describe(percentiles=pctiles))
     #  excludes NaN values. Percentiles can be customized,
@@ -409,7 +417,7 @@ def stat(data, pctiles=[0.25, 0.50, 0.75]):
 
 
 def stats(dataframe, n=3):
-    '''VERBOSE statistics on dataframe; CORRELATIONS without regression.'''
+    """VERBOSE statistics on dataframe; CORRELATIONS without regression."""
     print(dataframe.describe())
     print()
     print(" ::  Index on min:")
@@ -429,7 +437,7 @@ def stats(dataframe, n=3):
 
 
 def df2a(dataframe):
-    '''Convert single column dataframe to pure np.ndarray type.'''
+    """Convert single column dataframe to pure np.ndarray type."""
     #     After numpy operations, avoids getting single-value array,
     #     rather than the single-value itself which one would be expecting.
     #  Suppose len(dataframe) is m, then after dropna(),
@@ -443,9 +451,9 @@ def df2a(dataframe):
 #  TIP:  After operating between dataframes, USE todf FOR CLARITY:
 
 def todf(data, col='Y'):
-    '''CONVERT (list, Series, or DataFrame) TO DataFrame, NAMING single column.
+    """CONVERT (list, Series, or DataFrame) TO DataFrame, NAMING single column.
            Also from np.ndarray of shapes (N,) or (N,1).
-    '''
+    """
     #
     #  Operating among dataframes often produces a SERIES.
     #  We need CONVERSION for possible "paste" later,
@@ -467,7 +475,7 @@ def todf(data, col='Y'):
 
 
 def toar(data):
-    '''General converter to pure np.ndarray type.'''
+    """General converter to pure np.ndarray type."""
     #  Examples of data input types: list, Series, or single-column DataFrame,
     #           but also np.ndarray of shapes (N,) or (N,1).
     #  Why? Because some numerical packages ONLY work with arrays,
@@ -483,7 +491,7 @@ def toar(data):
 #  as part of getqdl() and getstocks().
 
 def names(data, col='Y', idx='T'):
-    '''Give names to single column of a dataframe and its index.'''
+    """Give names to single column of a dataframe and its index."""
     #  pandas has a confusing history of using .reindex and .rename
     #  but this works as of v5 (expect changes later from upstream):
     if isinstance(data, pd.DataFrame):
@@ -496,7 +504,7 @@ def names(data, col='Y', idx='T'):
 
 
 def paste(df_list):
-    '''Merge dataframes (not Series) across their common index values.'''
+    """Merge dataframes (not Series) across their common index values."""
     #  N.B. -  paste for pandas < 0.14 will fail
     #          if column names are not unique
     #          (newer pandas append _x to non-unique names).
@@ -516,7 +524,7 @@ def paste(df_list):
 
 
 def pastear(array_list):
-    '''Merge arrays as columns (like paste for dataframes).'''
+    """Merge arrays as columns (like paste for dataframes)."""
     #  N.B. -  To concatenate arrays horizontally, use np.hstack().
     #          To merge arrays as rows, use np.vstack().
     arr_tup = tuple(array_list)
@@ -524,7 +532,7 @@ def pastear(array_list):
 
 
 def lagdf(df, lags=1):
-    '''Create dataframe with lagged columns (labeled with underscore_lag).'''
+    """Create dataframe with lagged columns (labeled with underscore_lag)."""
     #  Argument df may have single or mutiple column(s).
     #  Argument lags can be any positive integer.
     #  N.B. -  useful data structure for vector autoregression of AR(lags).
@@ -541,7 +549,7 @@ def lagdf(df, lags=1):
 
 
 def diflog(data, lags=1):
-    '''Difference between lagged log(data).'''
+    """Difference between lagged log(data)."""
     #  If data is a DataFrame, it must be given as SINGLE-COLUMN.
     logged = np.log(todf(data))
     lagged = lagdf(logged, lags)
@@ -552,7 +560,7 @@ def diflog(data, lags=1):
 
 
 def writefile(dataframe, filename='tmp-fe-tool.csv', separator=','):
-    '''Write dataframe to disk file using UTF-8 encoding.'''
+    """Write dataframe to disk file using UTF-8 encoding."""
     #  For tab delimited, use '\t' as separator.
     dataframe.to_csv(filename, sep=separator, encoding='utf-8')
     print(' ::  Dataframe written to file: ' + filename)

--- a/fecon236/tool.py
+++ b/fecon236/tool.py
@@ -70,19 +70,24 @@ def tailvalue(df, pos=0, row=1):
 
 def div(numerator, denominator, floor=False):
     """Division via numpy for pandas, Python 2 and 3 compatibility.
-        Returns a scalar if both inputs are scalar, ndarray otherwise.
-        We shall AVOID the ambiguous python2-like: np.divide()
-    >>> x = np.array([0, 1, 2, 3, 4])
-    >>> div(x, 4, floor=False)
-    array([0.  ,  0.25,  0.5 ,  0.75,  1.])
-    >>> div(x, 4, floor=True)
-    array([0, 0, 0, 0, 1])
-    >>> div(2, 4, floor=True)
-    0
-    >>> div(2, 4)
-    0.5
-    >>> div(2, 0)  # Dividing by zero returns infinity, not error:
-    inf
+
+    Returns a scalar if both inputs are scalar, ``ndarray`` otherwise.
+    We shall AVOID the ambiguous python2-like: ``np.divide``
+
+    .. code-block:: python
+        :flake8-group: Ignore
+
+        >>> x = np.array([0, 1, 2, 3, 4])
+        >>> div(x, 4, floor=False)
+        array([0.  ,  0.25,  0.5 ,  0.75,  1.])
+        >>> div(x, 4, floor=True)
+        array([0, 0, 0, 0, 1])
+        >>> div(2, 4, floor=True)
+        0
+        >>> div(2, 4)
+        0.5
+        >>> div(2, 0)  # Dividing by zero returns infinity, not error:
+        inf
     """
     if floor:
         #      Like python3 "//":
@@ -115,13 +120,21 @@ def pcent(dfx, freq=1):
 
 def retrace(minimum, maximum, percent=50):
     """Compute retracement between minimum and maximum.
-        Noteworthy Fibonacci retracements: 23.6%, 38.2%, 61.8%
-        Set percent as negative for retracement down from maximum,
-        whereas positive percent implies retrace up from the minimum.
-    >>> retrace(10, 110, -20)
-    90.0
-    >>> retrace(10, 110, 20)
-    30.0
+
+    Noteworthy Fibonacci retracements: 23.6%, 38.2%, 61.8%
+    Set percent as negative for retracement down from maximum,
+    whereas positive percent implies retrace up from the minimum.
+
+    Usage
+    -----
+
+    code-block:: python
+        :flake8-group: Ignore
+
+        >>> retrace(10, 110, -20)
+        90.0
+        >>> retrace(10, 110, 20)
+        30.0
     """
     if isinstance(minimum, pd.DataFrame):
         system.die("DataFrame argument UNACCEPTABLE. Try retracedf()")
@@ -175,11 +188,15 @@ def georet(dfx, yearly=256):
 
 
 def zeroprice(rate, duration=9, yearly=2, face=100):
-    """Compute price of zero-coupon bond given its duration."""
-    #  Assume rate is in percentage form, e.g. 2.5% (not 0.025).
-    #         rate could be a dataframe column.
-    #  2014-08-28  duration of 10-y Treasury is 9.1 approx.
-    #  yearly refers to payouts per year, so 2 means semi-annual.
+    """Compute price of zero-coupon bond given its duration.
+
+    Assume ``rate`` is in percentage form, e.g. 2.5% (not 0.025).
+    ``rate`` could be a dataframe column.
+
+    2014-08-28  duration of 10-y Treasury is 9.1 approx.
+
+    ``yearly`` refers to payouts per year, so ``2`` means semi-annual.
+    """
     periodrate = rate / float(yearly * 100)
     periods = duration * yearly
     return float(face) / ((1 + periodrate) ** periods)
@@ -187,12 +204,22 @@ def zeroprice(rate, duration=9, yearly=2, face=100):
 
 def std(data, population=False):
     """Compute standard deviation with delta degrees of freedom, ddof.
-       Default population=False is compatible with pandas and MATLAB
-       since both defaults to SAMPLE standard deviation
-       (using so-called Bessel's correction of N-1).
+
+    Default ``population=False`` is compatible with pandas and MATLAB
+    since both defaults to SAMPLE standard deviation
+    (using so-called Bessel's correction of N-1).
+
+    Notes
+    -----
+
+    * ddof must be integer-valued (not boolean):
+
+    References
+    ----------
+
+    * https://stackoverflow.com/questions/27600207
+
     """
-    #  Ref: https://stackoverflow.com/questions/27600207
-    #  ddof must be integer-valued (not boolean):
     if population:
         ddof = 0   # For POPULATION standard deviation: numpy default!
     else:
@@ -233,47 +260,59 @@ def mad(dfy):
 
 def madmen(dfy):
     """Rescale data as unitless MAD multiples, after shifting median to zero.
+
     The main character in the "Mad Men" series pretending to be Donald Draper
     is akin to our data pretending to be Gaussian, which we robustly unmask.
-    [Cf. alternative normalize() where large deviations are squared.]
+    [Cf. ``alternative normalize`` where large deviations are squared.]
     """
     dev = dfy - median(dfy)  # Deviations from median.
     return dev / mad(dfy)
 
 
 def correlate(dfy, dfx, type='pearson'):
-    """CORRELATION FUNCTION between series using pandas method."""
-    #  N.B. -  must specify column(s) within dataframe(s) !
-    #              Types of correlations:
-    #  'pearson'   Standard correlation coefficient
-    #  'kendall' 	Kendall Tau correlation coefficient
-    #  'spearman' 	Spearman rank correlation coefficient
+    """CORRELATION FUNCTION between series using pandas method.
+
+    Notes
+    -----
+
+    * Must specify column(s) within dataframe(s)
+
+    Parameters
+    ----------
+    type: str, optional
+        Types of correlation coefficient ('pearson' - Standard, 'kendall' -
+        Kendall Tau, 'spearman' - Spearman rank)
+    """
     return dfy.corr(dfx, method=type)
 
 
 def cormatrix(dataframe, type='pearson'):
-    """PAIRWISE CORRELATIONS within a dataframe using pandas method."""
-    #              Types of correlations:
-    #  'pearson'   Standard correlation coefficient
-    #  'kendall' 	Kendall Tau correlation coefficient
-    #  'spearman' 	Spearman rank correlation coefficient
+    """PAIRWISE CORRELATIONS within a dataframe using pandas method
+
+    Parameters
+    ----------
+    type: str, optional
+        Types of correlation coefficient ('pearson' - Standard, 'kendall' -
+        Kendall Tau, 'spearman' - Spearman rank)
+    """
     return dataframe.corr(method=type)
 
 
 def regressformula(df, formula):
-    """Helper function for statsmodel linear regression using formula."""
-    #
-    #  FORMULA is a string like "Y ~ 0 + X + Z"
-    #          where column names of the df dataframe are used.
-    #          Omit the 0 if you want an intercept fitted.
-    #
-    #  USAGE given that: result = regressformula(...)
-    #        - print(result.summary())
-    #        - result.params
-    #        - coeff = result.params.tolist()
-    #        - result.rsquared is also available.
-    #        - result.aic is Akaike Information Criterion AIC.
-    #
+    """Helper function for statsmodel linear regression using formula.
+
+    FORMULA is a string like ``Y ~ 0 + X + Z`` where column names of the df
+    dataframe are used.
+
+    Omit the 0 if you want an intercept fitted.
+
+    USAGE given that: ``result = regressformula(...)``
+       - ``print(result.summary())``
+       - ``result.params``
+       - ``coeff = result.params.tolist()``
+       - ``result.rsquared`` is also available.
+       - ``result.aic`` is Akaike Information Criterion AIC.
+    """
     return smf.ols(formula=formula, data=df).fit()
 
 
@@ -365,8 +404,9 @@ def regress(dfy, dfx, intercept=True):
 
 def kurtfun(data, raw=False, population=False):
     """Compute kurtosis of an array or a single column DataFrame.
-       Default uses PEARSON fourth central moment, where kurtosis is 3
-       if data is Gaussian. Fischer "excess kurtosis":= k_Pearson-3.
+
+    Default uses PEARSON fourth central moment, where kurtosis is 3
+    if data is Gaussian. Fischer "excess kurtosis":= k_Pearson-3.
     """
     arr = toar(data)
     mu = np.mean(arr)

--- a/fecon236/top.py
+++ b/fecon236/top.py
@@ -1,28 +1,38 @@
 #  Python Module for import                           Date : 2018-06-17
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  top.py :: Top priority fecon236 experiments
+"""Top priority fecon236 experiments
 
-- TODO: Works in progress to be moved into a subdirectory upon maturity.
+.. note:: Works in progress to be moved into a subdirectory upon maturity.
 
-USAGE
-- More explicit syntax recommended: "import fecon236 as fe"
-  (Former usage in notebooks was casual: "from fecon235.fecon235 import *").
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
 
-REFERENCE
+Usage
+-----
+
+- More explicit syntax recommended: ``import fecon236 as fe`` (Former usage in
+  notebooks was casual: ``from fecon235.fecon235 import *``).
+
+References
+----------
+
 - Bloomberg Open Symbology which assigns a global ID for obscure financial
   instruments is now accessible via OpenFIGI, https://www.openfigi.com/search
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-17  Spin-off forefunds() to rates/fedfunds.py.
-                Spin-off foreinfl() to econ/infl.py.
-2018-06-16  Spin-off Holt-Winters section to tsa/holtwinters.py.
-2018-06-14  Spin-off group stuff to util/group.py.
-                Spin-off get() to host/hostess.py.
-2018-06-13  Rename to top.py, fecon236 fork. Lint bugs:
+Change Log
+----------
+
+* 2018-06-17  Spin-off ``forefunds`` to ``rates/fedfunds.py``. Spin-off
+  ``foreinfl`` to ``econ/infl.py``.
+* 2018-06-16  Spin-off Holt-Winters section to ``tsa/holtwinters.py``.
+* 2018-06-14  Spin-off group stuff to ``util/group.py``. Spin-off ``get`` to
+  ``host/hostess.py``.
+* 2018-06-13  Rename to top.py, fecon236 fork. Lint bugs:
                 too many undefined names (module specs) and bare excepts.
-2018-03-12  fecon235.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+* 2018-03-12  fecon235.py, fecon235 v5.18.0312, https://git.io/fecon235
+
+"""
 
 from __future__ import absolute_import, print_function, division
 

--- a/fecon236/tsa/holtwinters.py
+++ b/fecon236/tsa/holtwinters.py
@@ -75,7 +75,7 @@ References
 
 - Spyros Makridakis, 1978, *FORECASTING*, pp. 64-66.
    H-W does extremely well against ARIMA models in competitions.
-- Rob Hyndman, 2008, *Forecasting with Exponential Smoothing*,
+- Rob Hyndman, 2008, Forecasting with Exponential Smoothing,
    discusses level, growth (linear), and seasonal variants.
 - Sarah Gelper, 2007, *Robust Forecasting with Exponential
    and Holt-Winters smoothing*, useful for parameter values.

--- a/fecon236/tsa/holtwinters.py
+++ b/fecon236/tsa/holtwinters.py
@@ -234,8 +234,6 @@ def ema(y, alpha=0.20):
     return holtlevel(y, alpha, beta=0)
 
 
-
-
 def loss_holt(params, *args):
     """Loss function for holt() using np.median of absolute errors.
 
@@ -272,8 +270,6 @@ def loss_holt(params, *args):
     #
     #  Ignore the first ten errors due to initialization warm-up:
     return np.median(np.absolute(error[10:]))
-
-
 
 
 def optimize_holt(dataframe, grids=50, alphas=(0.0, 1.0), betas=(0.0, 1.0)):
@@ -353,4 +349,3 @@ def forecast(data, h=12, grids=0, maxi=0):
 
 if __name__ == "__main__":
     system.endmodule()
-

--- a/fecon236/tsa/holtwinters.py
+++ b/fecon236/tsa/holtwinters.py
@@ -1,52 +1,97 @@
 #  Python Module for import                           Date : 2018-06-16
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  holtwinters.py :: Holt-Winters time-series functions.
+"""Holt-Winters time-series functions.
 
 Holt-Winters is two-parameter linear growth exponential smoothing model.
 It has many uses, for example, stabilizing a time-series.
-For forecasting, the results are distilled in the forecast() function
+For forecasting, the results are distilled in the ``forecast`` function
 which features robust parameter optimization in the background.
 
-TESTS for this module are carried out in tests/test_holtwinters.py
+TESTS for this module are carried out in ``tests/test_holtwinters.py``
 and the doctests there show numerical examples of how some of our
 time-series algorithms are built.
 
 To optimally ESTIMATE Holt-Winters parameters alpha and beta,
 conditional on a particular dataset, for forecasting purposes
-(rather than smoothing), opt_holt.py was absorbed here on 2018-05-31.
+(rather than smoothing), ``opt_holt.py`` was absorbed here on 2018-05-31.
 
 USAGE of the code for the Holt-Winters time-series model is illustrated
 in the Jupyter notebook at https://git.io/gdpspx which is a rendering of
 nb/fred-gdp-spx.ipynb in the fecon235 repository.
 
-Note: rolling_* methods, including rolling_apply, only work on one-dimensional
-array, thus we may work outside pandas in numpy, then bring back the results.
-See pandas, http://pandas.pydata.org/pandas-docs/stable/computation.html
-and compare holt_winters_growth() vs. holt().
+Note: rolling_* methods, including ``rolling_apply``, only work on
+one-dimensional array, thus we may work outside pandas in numpy, then bring
+back the results.
+
+See ``pandas``, http://pandas.pydata.org/pandas-docs/stable/computation.html
+and compare ``holt_winters_growth`` vs. ``holt``.
 
 Details in comments: 2*sigma can be approximated by 3*(median_absolute_error).
 
 
-REFERENCES:
+Notes
+-----
 
-  - Spyros Makridakis, 1978, _FORECASTING_, pp. 64-66.
-       H-W does extremely well against ARIMA models in competitions.
-  - Rob Hyndman, 2008, _Forecasting with Exponential Smoothing_,
-       discusses level, growth (linear), and seasonal variants.
-  - Sarah Gelper, 2007, _Robust Forecasting with Exponential
-       and Holt-Winters smoothing_, useful for parameter values.
+For LATEST version, see https://git.io/fecon236
 
+Robust Optimal Estimation of alpha and beta
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-16  Absort Holt-Winters functions from top.py, esp. forecast().
-2018-05-31  ABSORB opt_holt module to estimate optimal alpha and beta.
-2018-05-11  Fix imports.
-2018-05-10  holtwinters.py, fecon236 fork. Pass flake8.
-2016-12-20  yi_timeseries.py, fecon235 v5.18.0312, https://git.io/fecon235
-2016-12-14  Fix initial guess of b[0] for holt_winters_growth(),
-                especially critical when beta=0 e.g. in new ema().
-'''
+We shall rely on ``optimize.minBrute`` to find optimal alpha and beta:
+
+- ``minBrute`` from optimize module: non-convex problem: GLOBAL optimizers:
+    If your problem does NOT admit a unique local minimum (which can be hard
+    to test unless the function is convex), and you do not have prior
+    information to initialize the optimization close to the solution: Brute
+    force uses a grid search: ``scipy.optimize.brute`` evaluates the function
+    on a given grid of parameters and returns the parameters corresponding to
+    the minimum value.
+
+    See ``oc/optimize.py`` for implementation details and references.
+    Also ``tests/test_optimize.py`` is intended as a TUTORIAL for USAGE.
+
+- GOAL: given some data and a MODEL, we want to MINIMIZE the LOSS FUNCTION
+    over possible values of the model's PARAMETERS.
+    Parameters which satisfy that goal are called BEST estimates
+    for the specified functional form.
+
+    Loss function should DISTINGUISH between parameters to be optimized,
+    and other supplemental arguments. The latter is introduced
+    via a tuple called funarg, frequently used to inject data.
+
+- We forego using RMSE (root mean squared errors) in favor of a more
+    ROBUST loss function since the squaring magnifies large errors.
+
+STATISTICAL NOTE: if L is the median absolute error, then by definition,
+``prob(-L <= error <= L) = 0.5``
+
+If we assume the errors are Gaussian centered around zero,
+then L = 0.675*sigma (by table look-up), thus sigma = 1.48*L.
+
+RULE of thumb: Two sigma confidence can be approximated by 3*L.
+
+References
+----------
+
+- Spyros Makridakis, 1978, *FORECASTING*, pp. 64-66.
+   H-W does extremely well against ARIMA models in competitions.
+- Rob Hyndman, 2008, *Forecasting with Exponential Smoothing*,
+   discusses level, growth (linear), and seasonal variants.
+- Sarah Gelper, 2007, *Robust Forecasting with Exponential
+   and Holt-Winters smoothing*, useful for parameter values.
+
+Change Log
+----------
+
+* 2018-06-16  Absort Holt-Winters functions from ``top.py``, esp. ``forecast``.
+* 2018-05-31  ABSORB ``opt_holt`` module to estimate optimal alpha and beta.
+* 2018-05-11  Fix imports.
+* 2018-05-10  ``holtwinters.py``, ``fecon236`` fork. Pass flake8.
+* 2016-12-20  ``yi_timeseries.py``, fecon235 v5.18.0312,
+  https://git.io/fecon235
+* 2016-12-14  Fix initial guess of b[0] for ``holt_winters_growth``,
+  especially critical when ``beta=0`` e.g. in new ``ema``.
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -66,7 +111,7 @@ hw_beta = 0.19       # for Gaussian, fat tail, and outlier data.
 
 
 def holt_winters_growth(y, alpha=hw_alpha, beta=hw_beta):
-    '''Helper for Holt-Winters growth (linear) model using numpy arrays.'''
+    """Helper for Holt-Winters growth (linear) model using numpy arrays."""
     #  N.B. -  SEASONAL variant of Holt-Winters is omitted.
     N = y.size             # y should be a numpy array.
     #                        0 < alpha and beta < 1
@@ -90,7 +135,7 @@ def holt_winters_growth(y, alpha=hw_alpha, beta=hw_beta):
 
 
 def holt(data, alpha=hw_alpha, beta=hw_beta):
-    '''Holt-Winters growth (linear) model outputs workout dataframe.'''
+    """Holt-Winters growth (linear) model outputs workout dataframe."""
     #  holt is an EXPENSIVE function, so retain its output for later.
     holtdf = todf(data).dropna()
     #              'Y'    ^else:
@@ -106,20 +151,22 @@ def holt(data, alpha=hw_alpha, beta=hw_beta):
 
 
 def holtlevel(data, alpha=hw_alpha, beta=hw_beta):
-    '''Just smoothed Level dataframe from Holt-Winters growth model.'''
-    #  Useful to filter out seasonals, e.g. see X-11 method:
-    #     http://www.sa-elearning.eu/basic-algorithm-x-11
+    """Just smoothed Level dataframe from Holt-Winters growth model.
+
+    Useful to filter out seasonals, e.g. see X-11 method:
+    http://www.sa-elearning.eu/basic-algorithm-x-11
+    """
     return todf(holt(data, alpha, beta)['Level'])
 
 
 def holtgrow(data, alpha=hw_alpha, beta=hw_beta):
-    '''Just the Growth dataframe from Holt-Winters growth model.'''
+    """Just the Growth dataframe from Holt-Winters growth model."""
     #  In terms of units expressed in data.
     return todf(holt(data, alpha, beta)['Growth'])
 
 
 def holtpc(data, yearly=256, alpha=hw_alpha, beta=hw_beta):
-    '''Annualized percentage growth dataframe from H-W growth model.'''
+    """Annualized percentage growth dataframe from H-W growth model."""
     #  yearly is the multiplier to annualize Growth.
     #
     #       MOST VALUABLE H-W function              <= !!
@@ -133,10 +180,14 @@ def holtpc(data, yearly=256, alpha=hw_alpha, beta=hw_beta):
 
 
 def holtforecast(holtdf, h=12):
-    '''Given a dataframe from holt, forecast ahead h periods.'''
-    #  N.B. -  holt forecasts by multiplying latest growth
-    #          by the number of periods ahead. Somewhat naive...
-    #          notice that the growth is based on smoothed levels.
+    """Given a dataframe from holt, forecast ahead h periods.
+
+    Notes
+    -----
+    N.B. -  holt forecasts by multiplying latest growth by the number of
+    periods ahead. Somewhat naive... notice that the growth is based on
+    smoothed levels.
+    """
     last = holtdf[-1:]
     y, l, b = last.values.tolist()[0]
     #         df to array to list, but extract first element:-(
@@ -146,10 +197,11 @@ def holtforecast(holtdf, h=12):
 
 
 def foreholt(data, h=12, alpha=hw_alpha, beta=hw_beta, maxi=0):
-    '''Data slang aware Holt-Winters holtforecast(), h-periods ahead.
-       Thus "data" can be a fredcode, quandlcode, stock slang,
-       OR a DataFrame should be detected.
-    '''
+    """Data slang aware Holt-Winters ``holtforecast``, h-periods ahead.
+
+    Thus "data" can be a fredcode, quandlcode, stock slang,
+    OR a DataFrame should be detected.
+    """
     if not isinstance(data, pd.DataFrame):
         try:
             data = get(data, maxi)
@@ -160,68 +212,43 @@ def foreholt(data, h=12, alpha=hw_alpha, beta=hw_beta, maxi=0):
 
 
 def holtfred(data, h=24, alpha=hw_alpha, beta=hw_beta):
-    '''Holt-Winters forecast h-periods ahead (fredcode aware).'''
+    """Holt-Winters forecast h-periods ahead (fredcode aware)."""
     #  Retained for backward compatibility, esp. pre-2016 notebooks.
     return foreholt(data, h, alpha, beta)
 
 
 def plotholt(holtdf, h=12):
-    '''Given a dataframe from holt, plot forecasts h periods ahead.'''
+    """Given a dataframe from holt, plot forecasts ``h`` periods ahead."""
     #  plotdf will not work since index there is assumed to be dates.
     holtforecast(holtdf, h).plot(title='Holt-Winters linear forecast')
     return
 
 
 def ema(y, alpha=0.20):
-    '''EXPONENTIAL MOVING AVERAGE using traditional weight arg.'''
-    #  y could be a dataframe.
-    #  ema is mathematically equivalent to holtlevel with beta=0,
-    #  thus issue #5 can be easily resolved for all pandas versions.
+    """EXPONENTIAL MOVING AVERAGE using traditional weight arg.
+
+    ``y`` could be a dataframe.
+    ema is mathematically equivalent to holtlevel with beta=0,
+    thus issue #5 can be easily resolved for all pandas versions.
+    """
     return holtlevel(y, alpha, beta=0)
 
 
-# ============================= ROBUST OPTIMAL ESTIMATION of alpha and beta ===
-'''
-We shall rely on optimize.minBrute() to find optimal alpha and beta:
-
-- minBrute() from optimize module: non-convex problem: GLOBAL optimizers:
-    If your problem does NOT admit a unique local minimum (which can be hard
-    to test unless the function is convex), and you do not have prior
-    information to initialize the optimization close to the solution: Brute
-    force uses a grid search: scipy.optimize.brute() evaluates the function on
-    a given grid of parameters and returns the parameters corresponding to the
-    minimum value.
-
-    See oc/optimize.py for implementation details and references.
-    Also tests/test_optimize.py is intended as a TUTORIAL for USAGE.
-
-- GOAL: given some data and a MODEL, we want to MINIMIZE the LOSS FUNCTION
-    over possible values of the model's PARAMETERS.
-    Parameters which satisfy that goal are called BEST estimates
-    for the specified functional form.
-
-    Loss function should DISTINGUISH between parameters to be optimized,
-    and other supplemental arguments. The latter is introduced
-    via a tuple called funarg, frequently used to inject data.
-
-- We forego using RMSE (root mean squared errors) in favor of a more
-    ROBUST loss function since the squaring magnifies large errors.
-
-STATISTICAL NOTE: if L is the median absolute error, then by definition,
-                  prob(-L <= error <= L) = 0.5
-    If we assume the errors are Gaussian centered around zero,
-    then L = 0.675*sigma (by table look-up), thus sigma = 1.48*L.
-
-    RULE of thumb: Two sigma confidence can be approximated by 3*L.
-'''
 
 
 def loss_holt(params, *args):
-    '''Loss function for holt() using np.median of absolute errors.
-       This is much more robust than using np.sum or np.mean
-       (and perhaps better than editing "outliers" out of data).
-       The error array will consist of 1-step ahead prediction errors.
-    '''
+    """Loss function for holt() using np.median of absolute errors.
+
+    This is much more robust than using np.sum or ``np.mean`` (and perhaps
+    better than editing "outliers" out of data). The error array will consist
+    of 1-step ahead prediction errors.
+
+    Notes
+    -----
+    TUPLE ``funarg`` is used to specify arguments to function ``fun`` which are
+    NOT the parameters to be optimized (e.g. data). Gotcha: Remember a
+    single-element tuple must include that mandatory comma: (alone,)
+    """
     alpha, beta = params  # Must specify arguments.
     data = args[0]        # Primary data assumed to be single column.
     #
@@ -247,19 +274,17 @@ def loss_holt(params, *args):
     return np.median(np.absolute(error[10:]))
 
 
-#  NOTICE: TUPLE "funarg" is used to specify arguments to function "fun"
-#          which are NOT the parameters to be optimized (e.g. data).
-#          Gotcha: Remember a single-element tuple must include
-#          that mandatory comma: (alone,)
 
 
 def optimize_holt(dataframe, grids=50, alphas=(0.0, 1.0), betas=(0.0, 1.0)):
-    '''Optimize Holt-Winters parameters alpha and beta for given data.
-       The alphas and betas are boundaries of respective explored regions.
-       Function interpolates "grids" from its low bound to its high bound,
-       inclusive. Final output: [alpha, beta, losspc, median absolute loss]
-       TIP: narrow down alphas and betas using optimize_holt iteratively.
-    '''
+    """Optimize Holt-Winters parameters alpha and beta for given data.
+
+    The ``alphas`` and ``betas`` are boundaries of respective explored regions.
+    Function interpolates ``grids`` from its low bound to its high bound,
+    inclusive. Final output: ``[alpha, beta, losspc, median absolute loss]``
+    TIP: narrow down ``alphas`` and ``betas`` using ``optimize_holt``
+    iteratively.
+    """
     if grids > 49:
         system.warn("Optimizing Holt-Winters alphabetaloss may take TIME!")
         #  Exploring loss at all the grids is COMPUTATIONALLY INTENSE
@@ -279,9 +304,13 @@ def optimize_holt(dataframe, grids=50, alphas=(0.0, 1.0), betas=(0.0, 1.0)):
 
 
 def optimize_holtforecast(dataframe, h=12, grids=50):
-    '''Forecast ahead h periods using optimized Holt-Winters parameters.'''
-    #  Note: default hw_alpha and hw_beta from yi_timeseries module
-    #        are NOT necessarily optimal given specific data.
+    """Forecast ahead h periods using optimized Holt-Winters parameters.
+
+    Notes
+    -----
+    Default ``hw_alpha`` and ``hw_beta`` from ``yi_timeseries`` module are NOT
+    necessarily optimal given specific data.
+    """
     alphabetaloss = optimize_holt(dataframe, grids=grids)
     #  alphabetaloss will be a list: [alpha, beta, losspc, loss]
     #     computed from default boundpairs: alphas=(0.0, 1.0), betas=(0.0, 1.0)
@@ -297,13 +326,15 @@ def optimize_holtforecast(dataframe, h=12, grids=50):
 
 
 def forecast(data, h=12, grids=0, maxi=0):
-    '''h-period ahead forecasts by holtforecast or optimize_holtforecast,
-       where "data" may be fredcode, quandlcode, stock slang, or DataFrame.
-       Given default grids argument, forecast is very QUICK since we use
-       FIXED parameters implicitly: alpha=hw_alpha and beta=hw_beta.
-       Recommend grids=50 for reasonable results, but it is TIME-CONSUMING
-       for search grids > 49 to find OPTIMAL alpha and beta.
-    '''
+    """h-period ahead forecasts by holtforecast or optimize_holtforecast.
+
+
+    ``data`` may be fredcode, quandlcode, stock slang, or DataFrame.
+    Given default grids argument, forecast is very QUICK since we use
+    FIXED parameters implicitly: ``alpha=hw_alpha`` and ``beta=hw_beta``.
+    Recommend ``grids=50`` for reasonable results, but it is TIME-CONSUMING
+    for search ``grids > 49`` to find OPTIMAL alpha and beta.
+    """
     if not isinstance(data, pd.DataFrame):
         try:
             data = get(data, maxi)
@@ -323,10 +354,3 @@ def forecast(data, h=12, grids=0, maxi=0):
 if __name__ == "__main__":
     system.endmodule()
 
-
-# ======================================================= ENDNOTES ============
-
-#  #  Table 3-8 from Makridakis 1978:
-#  makridakis_p65 = np.array([143, 152, 161, 139, 137, 174, 142, 141, 162,
-#                            180, 164, 171, 206, 193, 207, 218, 229, 225, 204,
-#                            227, 223, 242, 239, 266])

--- a/fecon236/util/group.py
+++ b/fecon236/util/group.py
@@ -1,14 +1,19 @@
 #  Python Module for import                           Date : 2018-06-17
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  group.py :: Group utilities
+"""Group utilities
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-17  Spin-off groupcotr() to futures.cftc module.
-2018-06-16  Move covdiflog() to math.matrix module.
-2018-06-14  Spin-off group stuff from top.py.
-2018-03-12  fecon235.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+Change Log
+----------
+
+* 2018-06-17  Spin-off ``groupcotr`` to ``futures.cftc`` module.
+* 2018-06-16  Move ``covdiflog`` to ``math.matrix`` module.
+* 2018-06-14  Spin-off group stuff from ``top.py``.
+* 2018-03-12  ``fecon235.py``, fecon235 v5.18.0312, https://git.io/fecon235
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -36,7 +41,7 @@ world4d = {'America': 's4spy', 'Europe': 's4ezu',
 
 
 def groupget(ggdic=group4d, maxi=0):
-    '''Retrieve and create group dataframe, given group dictionary.'''
+    """Retrieve and create group dataframe, given group dictionary."""
     #  Since dictionaries are unordered, create SORTED list of keys:
     keys = [key for key in sorted(ggdic)]
     #  Download individual dataframes as values into a dictionary:
@@ -50,11 +55,16 @@ def groupget(ggdic=group4d, maxi=0):
 
 
 def groupfun(fun, groupdf, *pargs, **kwargs):
-    '''Use fun(ction) column-wise, then output new group dataframe.'''
-    #  In mathematics, this is known as an "operator":
-    #      a function which takes another function as argument.
-    #  Examples of fun: pcent, normalize, etc. See grouppc() next.
-    #  See groupget() to retrieve and create group dataframe.
+    """Use fun(ction) column-wise, then output new group dataframe.
+
+    Notes
+    -----
+    In mathematics, this is known as an "operator":
+    a function which takes another function as argument.
+    Examples of fun: ``pcent``, ``normalize``, etc. See ``grouppc`` next.
+
+    .. seealso:: ``groupget`` to retrieve and create group dataframe.
+    """
     keys = list(groupdf.columns)
     #  Compute individual columns as dataframes in a list:
     out = [tool.todf(fun(tool.todf(groupdf[key]), *pargs, **kwargs))
@@ -68,24 +78,33 @@ def groupfun(fun, groupdf, *pargs, **kwargs):
 
 
 def grouppc(groupdf, freq=1):
-    '''Create overlapping pcent dataframe, given a group dataframe.'''
-    #  See groupget() to retrieve and create group dataframe.
-    #  Very useful to visualize as boxplot, see fred-georeturns.ipynb
+    """Create overlapping pcent dataframe, given a group dataframe.
+
+    Notes
+    -----
+    .. seealso:: ``groupget`` to retrieve and create group dataframe.
+
+    Very useful to visualize as boxplot, see fred-georeturns.ipynb
+    """
     return groupfun(tool.pcent, groupdf, freq)
 
 
 def groupdiflog(groupdf, lags=1):
-    '''Difference between lagged log(data) for columns in group dataframe.'''
-    #  See groupget() to retrieve and create group dataframe.
+    """Difference between lagged log(data) for columns in group dataframe.
+
+    .. seealso:: See ``groupget`` to retrieve and create group dataframe.
+    """
     return groupfun(tool.diflog, groupdf, lags)
 
 
 def groupgeoret(groupdf, yearly=256, order=True):
-    '''Geometric mean returns, non-overlapping, for group dataframe.
-       Argument "yearly" refers to annual frequency, e.g.
-       256 for daily trading days, 12 for monthly, 4 for quarterly.
-       ATTN: Use groupgemrat() instead for greater accuracy.
-    '''
+    """Geometric mean returns, non-overlapping, for group dataframe.
+
+    Argument ``yearly`` refers to annual frequency, e.g.
+    256 for daily trading days, 12 for monthly, 4 for quarterly.
+
+    .. note:: Use ``groupgemrat`` instead for greater accuracy.
+    """
     keys = list(groupdf.columns)
     #  Use list comprehension to store lists from georet():
     geo = [tool.georet(tool.todf(groupdf[k]), yearly) + [k] for k in keys]
@@ -97,12 +116,13 @@ def groupgeoret(groupdf, yearly=256, order=True):
 
 
 def groupgemrat(groupdf, yearly=256, order=False, n=2):
-    '''Geometric mean rates, non-overlapping, for group dataframe.
-       Argument "yearly" refers to annual frequency, e.g.
-       256 for daily trading days, 12 for monthly, 4 for quarterly.
-       Output is rounded to n-decimal places.
-       Algorithm takes KURTOSIS into account for greater accuracy.
-    '''
+    """Geometric mean rates, non-overlapping, for group dataframe.
+
+    Argument ``yearly`` refers to annual frequency, e.g.
+    256 for daily trading days, 12 for monthly, 4 for quarterly.
+    Output is rounded to n-decimal places.
+    Algorithm takes KURTOSIS into account for greater accuracy.
+    """
     keys = list(groupdf.columns)
     #  Use list comprehension to store lists from gemrat():
     gem = [tool.roundit(gemrat(tool.todf(groupdf[k]), yearly), n, echo=False)
@@ -115,7 +135,7 @@ def groupgemrat(groupdf, yearly=256, order=False, n=2):
 
 
 def groupholtf(groupdf, h=12, alpha=hw.hw_alpha, beta=hw.hw_beta):
-    '''Holt-Winters forecasts h-periods ahead from group dataframe.'''
+    """Holt-Winters forecasts h-periods ahead from group dataframe."""
     forecasts = []
     keys = list(groupdf.columns)
     for k in keys:

--- a/fecon236/util/system.py
+++ b/fecon236/util/system.py
@@ -1,29 +1,36 @@
 #  Python Module for import                           Date : 2018-06-20
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  system.py :: system and date functions including specs.
+"""System and date functions including specs.
 
-Code in this module should be compatible with both Python 2 and 3
-until 2019-01-01, thereafter only python3.
+.. note:: Code in this module should be compatible with both Python 2 and 3
+          until 2019-01-01, thereafter only python3.
 
 For example, it is used in the preamble of fecon235 Jupyter notebooks.
 
 
-REFERENCES:
+Notes
+-----
+For latest version, see https://git.io/fecon236
+
+
+References
+----------
+
 - Compatible IDIOMS: http://python-future.org/compatible_idioms.html
-                     Nice presentation.
-
+  Nice presentation.
 - SIX module is exhaustive: https://pythonhosted.org/six/
-        Single file source: https://bitbucket.org/gutworth/six
+  Single file source: https://bitbucket.org/gutworth/six
 
 
-CHANGE LOG  For latest version, see https://git.io/fecon236
-2018-06-20  Update specs(), include version for statsmodels.
-2018-05-15  Include version("fecon236") to specs.
-2018-04-25  Ignore "raw_input" < python3 flake8.
-2018-04-21  yi_0sys module from fecon235 renamed to system.
-                Major flake8 fixes. Move notebook preamble to docs.
-'''
+Change Log
+----------
+
+* 2018-06-20  Update ``specs``, include version for ``statsmodels``.
+* 2018-05-15  Include ``version("fecon236")`` to ``specs``.
+* 2018-04-25  Ignore ``raw_input`` < python3 flake8.
+* 2018-04-21  ``yi_0sys`` module from fecon235 renamed to system.
+  Major flake8 fixes. Move notebook preamble to docs.
+"""
 
 # py2rm
 from __future__ import absolute_import, print_function
@@ -53,25 +60,30 @@ dev_null = os.open(os.devnull, os.O_RDWR)
 
 
 def getpwd():
-    '''Get present working directory (Linux command is pwd).
-       Works cross-platform, giving absolute path.
-    '''
+    """Get present working directory (Linux command is pwd).
+
+    Works cross-platform, giving absolute path.
+    """
     return os.getcwd()
 
 
 def program():
-    '''Get name of present script; works cross-platform.'''
-    #  Note: __file__ can get only the name of this module.
+    """Get name of present script; works cross-platform.
+
+    Notes
+    -----
+    ``__file__`` can get only the name of this module.
+    """
     return os.path.basename(sys.argv[0])
 
 
 def warn(message, stub="WARNING:", prefix=" !. "):
-    '''Write warning solely to standard error.'''
+    """Write warning solely to standard error."""
     print(prefix, stub, program(), message, sep=' ', file=sys.stderr)
 
 
 def die(message, errcode=1, prefix=" !! "):
-    '''Gracefully KILL script, optionally specifying error code.'''
+    """Gracefully KILL script, optionally specifying error code."""
     stub = "FATAL " + str(errcode) + ":"
     warn(message, stub, prefix)
     sys.exit(errcode)
@@ -82,11 +94,12 @@ def die(message, errcode=1, prefix=" !! "):
 
 
 def date(hour=True, utc=True, localstr=' Local'):
-    '''Get date, and optionally time, as ISO string representation.
-       Boolean hour variable also gives minutes and seconds.
-       Setting utc to False will give local time instead of UTC,
-       then localstr can be used to indicate location.
-    '''
+    """Get date, and optionally time, as ISO string representation.
+
+    Boolean ``hour`` variable also gives minutes and seconds.
+    Setting ``utc`` to ``False`` will give local time instead of UTC,
+    then ``localstr`` can be used to indicate location.
+    """
     if hour:
         form = "%Y-%m-%d, %H:%M:%S"
     else:
@@ -101,21 +114,25 @@ def date(hour=True, utc=True, localstr=' Local'):
 
 
 def timestamp():
-    '''Timestamp per strict RFC-3339 standard where timezone Z:=UTC.'''
+    """Timestamp per strict RFC-3339 standard where timezone Z:=UTC."""
     form = "%Y-%m-%dT%H:%M:%SZ"
     tup = time.gmtime()
     return time.strftime(form, tup)
 
 
 def pythontup():
-    '''Represent invoked Python version as an integer 3-tuple.'''
-    #  Using sys.version is overly verbose.
-    #  Here we get something like (2, 7, 10) which can be compared.
+    """Represent invoked Python version as an integer 3-tuple.
+
+    Notes
+    -----
+    Using sys.version is overly verbose. Here we get something like (2, 7, 10)
+    which can be compared.
+    """
     return sys.version_info[:3]
 
 
 def versionstr(module="IPython"):
-    '''Represent version as a string, or None if not installed.'''
+    """Represent version as a string, or None if not installed."""
     #  Unfortunately must treat Python vs its modules differently...
     if module == "Python" or module == "python":
         ver = pythontup()
@@ -131,7 +148,7 @@ def versionstr(module="IPython"):
 
 
 def versiontup(module="IPython"):
-    '''Parse version string into some integer 3-tuple.'''
+    """Parse version string into some integer 3-tuple."""
     s = versionstr(module)
     try:
         v = [int(k) for k in s.split('.')]
@@ -145,14 +162,17 @@ def versiontup(module="IPython"):
 
 
 def version(module="IPython"):
-    '''Pretty print Python or module version info.'''
+    """Pretty print Python or module version info."""
     print(" :: ", module, versionstr(module))
 
 
 def utf(immigrant, xnl=True):
-    '''Convert to utf-8, and possibly delete new line character.
-       xnl means "delete new line"
-    '''
+    """Convert to utf-8, and possibly delete new line character.
+
+    Notes
+    -----
+    ``xnl`` means "delete new line"
+    """
     if xnl:
         #                Decodes to utf-8, plus deletes new line.
         return immigrant.decode('utf-8').strip('\n')
@@ -162,25 +182,39 @@ def utf(immigrant, xnl=True):
 
 
 def run(command, xnl=True, errf=None):
-    '''RUN **quote and space insensitive** SYSTEM-LEVEL command.
-       OTHERWISE: use check_output directly and list component
-       parts of the command, e.g.
-           check_output(["git", "describe", "--abbrev=0"])
-       then generally use our utf() since check_output
-       usually does not return utf-8, so be prepared to
-       receive bytes and also new line.
-    '''
-    #  N.B. -  errf=None means the usual error transmittal.
-    #          Cross-platform /dev/stdout is STDOUT
-    #          Cross-platform /dev/null   is our dev_null above.
-    #  https://docs.python.org/2/library/subprocess.html
+    """RUN **quote and space insensitive** SYSTEM-LEVEL command.
+
+    OTHERWISE: use ``check_output`` directly and list component
+    parts of the command, e.g.
+       ``check_output(["git", "describe", "--abbrev=0"])``
+    then generally use our ``utf`` since check_output
+    usually does not return utf-8, so be prepared to
+    receive bytes and also new line.
+
+    Notes
+    -----
+
+    - ``errf=None`` means the usual error transmittal.
+    - Cross-platform /dev/stdout is STDOUT
+    - Cross-platform /dev/null   is our dev_null above.
+
+    References
+    ----------
+
+    - https://docs.python.org/2/library/subprocess.html
+
+    """
     return utf(check_output(command.split(), stderr=errf), xnl)
 
 
 def gitinfo():
-    '''From git, get repo name, current branch and annotated tag.'''
-    #  Suppressing error messages by os.devnull seems cross-platform,
-    #  but it is just a string, so use our open file dev_null instead.
+    """From git, get repo name, current branch and annotated tag.
+
+    Notes
+    -----
+    Suppressing error messages by ``os.devnull`` seems cross-platform,
+    but it is just a string, so use our open file dev_null instead.
+    """
     try:
         repopath = run("git rev-parse --show-toplevel", errf=dev_null)
         #              ^returns the dir path plus working repo name.
@@ -196,9 +230,12 @@ def gitinfo():
 
 
 def specs():
-    '''Show ecosystem specifications, including execution timestamp.
-       APIs are subject to change, so versions are critical for replication.
-    '''
+    """Show ecosystem specifications, including execution timestamp.
+
+    Notes
+    -----
+    APIs are subject to change, so versions are critical for replication.
+    """
     if pythontup() < minimumPython:
         warn("This project requires a more recent Python version.")
     else:
@@ -222,15 +259,15 @@ def specs():
 
 
 def endmodule():
-    '''Procedure after __main__ conditional in modules.'''
+    """Procedure after ``__main__`` conditional in modules."""
     die("is a MODULE for import, not for direct execution.", 113)
 
 
 # py2rm
-'''ROSETTA STONE FUNCTIONS approximately bridging Python 2 and 3.
+"""ROSETTA STONE FUNCTIONS approximately bridging Python 2 and 3.
    e.g.    answer = get_input("Favorite animal? ")
            print(answer)
-'''
+"""
 if pythontup() < (3, 0, 0):
     get_input = raw_input   # noqa
 else:

--- a/fecon236/util/system.py
+++ b/fecon236/util/system.py
@@ -185,11 +185,9 @@ def run(command, xnl=True, errf=None):
     """RUN **quote and space insensitive** SYSTEM-LEVEL command.
 
     OTHERWISE: use ``check_output`` directly and list component
-    parts of the command, e.g.
-       ``check_output(["git", "describe", "--abbrev=0"])``
-    then generally use our ``utf`` since check_output
-    usually does not return utf-8, so be prepared to
-    receive bytes and also new line.
+    parts of the command, e.g. ``check_output(["git", "describe",
+    "--abbrev=0"])`` then generally use our ``utf`` since check_output usually
+    does not return utf-8, so be prepared to receive bytes and also new line.
 
     Notes
     -----

--- a/fecon236/visual/plots.py
+++ b/fecon236/visual/plots.py
@@ -1,7 +1,6 @@
 #  Python Module for import                           Date : 2018-06-08
 #  vim: set fileencoding=utf-8 ff=unix tw=78 ai syn=python : per PEP 0263
-'''
-_______________|  plots.py :: Plot functions using matplotlib.
+"""Plot functions using matplotlib.
 
 Functions to plot data look routine, but in actuality specifying
 the details can be a huge hassle involving lots of trial and error.
@@ -13,24 +12,30 @@ conserving disk space. Specifying a title NOT starting with 'tmp'
 will produce a PNG image file. Moreover, it is possible to
 suppress screen show by adding a leading blank space to the title.
 
-REFERENCES:
+Notes
+-----
+For LATEST version, see https://git.io/fecon236
+
+References
+----------
 
 - matplotlib, http://matplotlib.org/api/pyplot_api.html
-
 - pandas, http://pandas.pydata.org/pandas-docs/stable/computation.html
 
 
-CHANGE LOG  For LATEST version, see https://git.io/fecon236
-2018-06-08  Clarify plotn() usage.
-2018-05-20  Use functools.wraps within saveImage decorator.
-2018-05-17  Suppress show screen via leading space in title.
-                Fix boxplot() by removing NaN from data.
-2018-05-16  MAJOR refactoring using decorator saveImage().
-2018-05-14  Transplant plot() but deprecate use of symbol code as argument.
-2018-05-11  Fix imports.
-2018-05-09  plots.py, fecon236 fork. Pass flake8.
-2017-05-15  yi_plot.py, fecon235 v5.18.0312, https://git.io/fecon235
-'''
+Change Log
+----------
+
+* 2018-06-08  Clarify ``plotn`` usage.
+* 2018-05-20  Use ``functools.wraps`` within saveImage decorator.
+* 2018-05-17  Suppress show screen via leading space in title.
+  Fix ``boxplot`` by removing NaN from data.
+* 2018-05-16  MAJOR refactoring using decorator ``saveImage``.
+* 2018-05-14  Transplant ``plot`` but deprecate use of symbol code as argument.
+* 2018-05-11  Fix imports.
+* 2018-05-09  ``plots.py``, ``fecon236`` fork. Pass flake8.
+* 2017-05-15  ``yi_plot.py``, fecon235 v5.18.0312, https://git.io/fecon235
+"""
 
 from __future__ import absolute_import, print_function, division
 
@@ -53,13 +58,13 @@ dotsperinch = 140
 
 
 def saveImage(func):
-    '''Decorator to save plot image to disk, option to suppress screen show.'''
+    """Decorator to save plot image to disk, option to suppress screen show."""
     #  The underlying func MUST "return [title, fig]".
     #  Image saved to file ONLY if title string does NOT start with 'tmp'.
     #  Screen show can be suppressed by a leading blank space in title arg.
     @wraps(func)
     def saveimage(*args, **kwargs):
-        '''Wrapper for the decorator saveImage.'''
+        """Wrapper for the decorator saveImage."""
         title, fig = func(*args, **kwargs)
         if not title.startswith(' '):
             plt.show()
@@ -78,7 +83,7 @@ def saveImage(func):
 
 @saveImage
 def plotdf(dataframe, title='tmp'):
-    '''Plot dataframe where its index are dates.'''
+    """Plot dataframe where its index are dates."""
     dataframe = tool.todf(dataframe)
     #                ^todf must dropna(),
     #                 otherwise index of last point plotted may be wrong.
@@ -101,10 +106,11 @@ def plotdf(dataframe, title='tmp'):
 
 #  saveImage decorator not needed here.
 def plot(data, title='tmp', maxi=87654321):
-    '''Wrapper around plotdf() which accepts DataFrame with date index.
-       For list or numbered index, use plotn() instead.
-       Backwards-compatible maxi is maximum number of most recent data.
-    '''
+    """Wrapper around ``plotdf`` which accepts DataFrame with date index.
+
+    For list or numbered index, use ``plotn`` instead.
+    Backwards-compatible maxi is maximum number of most recent data.
+    """
     if isinstance(data, pd.DataFrame):
         plotdf(tool.tail(data, maxi), title)
     else:
@@ -117,7 +123,7 @@ def plot(data, title='tmp', maxi=87654321):
 
 @saveImage
 def plotn(data, title='tmp'):
-    '''Plot list, array, Series, or DataFrame where the index is numbered.'''
+    """Plot list, array, Series, or DataFrame where the index is numbered."""
     #  With todf: list, array, or Series will be converted to DataFrame.
     dataframe = tool.todf(data)
     #               ^todf must dropna(),
@@ -139,7 +145,7 @@ def plotn(data, title='tmp'):
 
 @saveImage
 def boxplot(data, title='tmp', labels=[]):
-    '''Make boxplot from data which could be a dataframe.'''
+    """Make boxplot from data which could be a dataframe."""
     #  - Use list of strings for labels,
     #       since we presume data has no column names,
     #       unless data is a dataframe.
@@ -179,7 +185,7 @@ def boxplot(data, title='tmp', labels=[]):
 
 @saveImage
 def scatter(dataframe, title='tmp', col=[0, 1]):
-    '''Scatter plot for dataframe by zero-based column positions.'''
+    """Scatter plot for dataframe by zero-based column positions."""
     #  First in col is x-axis, second is y-axis.
     #  Index itself is excluded from position numbering.
     dataframe = dataframe.dropna()
@@ -214,7 +220,7 @@ def scatter(dataframe, title='tmp', col=[0, 1]):
 
 #  saveImage decorator not needed here.
 def scats(dataframe, title='tmp'):
-    '''All pair-wise scatter plots for dataframe.'''
+    """All pair-wise scatter plots for dataframe."""
     #  Renaming title will result in file output.
     ncol = dataframe.shape[1]
     #                ^number of columns
@@ -233,7 +239,7 @@ def scats(dataframe, title='tmp'):
 
 #  saveImage decorator not needed here.
 def scat(dfx, dfy, title='tmp', col=[0, 1]):
-    '''Scatter plot between two pasted dataframes.'''
+    """Scatter plot between two pasted dataframes."""
     #  Renaming title will result in file output.
     scatter(tool.paste([dfx, dfy]), title, col)
     return
@@ -249,10 +255,16 @@ def scat(dfx, dfy, title='tmp', col=[0, 1]):
 
 @saveImage
 def plotqq(data, title='tmp', dist='norm', fitLS=True):
-    '''Display/save quantile-quantile Q-Q probability plot.
+    """Display/save quantile-quantile Q-Q probability plot.
+
     Q–Q plot here is used to compare data to a theoretical distribution.
-    Ref: https://en.wikipedia.org/wiki/Q–Q_plot
-    '''
+
+    References
+    ----------
+
+    * https://en.wikipedia.org/wiki/Q–Q_plot
+
+    """
     #     Assume "data" to be np.ndarray or single-column DataFrame.
     #  Theoretical quantiles on horizontal x-axis estimated by Filliben method.
     #  Green line depicits theoretical distribution; fitLS computes R^2:


### PR DESCRIPTION
### Proposed changes in this pull request for fecon236

*In Progress*

* Converts all docstrings in source code (except tests) to numpy format 
   (https://numpydoc.readthedocs.io/en/latest/format.html).
* Adds ``test_formatting`` utility script to test both source code and docstring formatting

This will enable easy auto-documentation using ``sphinx-autodoc``.

- [x] Documentation change :memo:
- [x] Enhancement :art:





### Additional helpful details

- [x] REQUIRE: PR rebased on *latest* `develop` branch
- [x] This pull request needs to be manually tested
- [x] Work-in-progress: more changes will follow
- [x] Issue requires further discussion
- [ ] Issue has been fully resolved





ATTN mention: @rsvp

